### PR TITLE
Increase cmdargs upper bound to < 0.10

### DIFF
--- a/diagrams-svg.cabal
+++ b/diagrams-svg.cabal
@@ -38,7 +38,7 @@ Library
                      , diagrams-core >= 0.5   && < 0.6
                      , diagrams-lib  >= 0.5   && < 0.6
                      , blaze-svg >= 0.3.3
-                     , cmdargs       >= 0.6   && < 0.9
+                     , cmdargs       >= 0.6   && < 0.10
                      , split         >= 0.1.2 && < 0.2
   if !os(windows)
     cpp-options: -DCMDLINELOOP


### PR DESCRIPTION
The latest version of cmdargs is 0.9.5 (which works fine with diagrams-svg).  Moreover, previous versions of cmdargs require transformers < 0.3 so this update is important for supporting transformers-0.3.
