### PR TITLE
ghc-7.6 

### DIFF
--- a/diagrams-svg.cabal
+++ b/diagrams-svg.cabal
@@ -28,22 +28,22 @@ Library
   Other-modules:       Graphics.Rendering.SVG
   Hs-source-dirs:      src
   Build-depends:       base          >= 4.3   && < 4.7
-                     , old-time >= 1.0 && < 1.2
                      , process >= 1.0 && < 1.2
-                     , directory >= 1.0 && < 1.2
+                     , directory >= 1.0 && < 1.3
                      , filepath >= 1.2 && < 1.4
                      , mtl         >= 1      && < 3.0
                      , bytestring    >= 0.9   && < 1.0
                      , vector-space  >= 0.7   && < 0.9
                      , colour
-                     , diagrams-core >= 0.6   && < 0.7
-                     , diagrams-lib  >= 0.6   && < 0.7
+                     , diagrams-core >= 0.5   && < 0.7
+                     , diagrams-lib  >= 0.5   && < 0.7
                      , blaze-svg >= 0.3.3
                      , cmdargs       >= 0.6   && < 0.11
                      , split         >= 0.1.2 && < 0.3
+                     , time
   if !os(windows)
     cpp-options: -DCMDLINELOOP
-    Build-depends:     unix >= 2.4 && < 2.6
+    Build-depends:     unix >= 2.4 && < 2.7
 
   Ghc-options:         -Wall
 

--- a/src/Diagrams/Backend/SVG/CmdLine.hs
+++ b/src/Diagrams/Backend/SVG/CmdLine.hs
@@ -24,21 +24,21 @@ import System.Console.CmdArgs.Implicit hiding (args)
 import Text.Blaze.Svg.Renderer.Utf8 (renderSvg)
 import qualified Data.ByteString.Lazy as BS
 
-import Prelude hiding      (catch)
 
 import Data.Maybe          (fromMaybe)
 import Control.Monad       (when)
 import Data.List.Split
 
 import System.Environment  (getArgs, getProgName)
-import System.Directory    (getModificationTime)
+import System.Directory   -- (getModificationTime)
 import System.Process      (runProcess, waitForProcess)
 import System.IO           (openFile, hClose, IOMode(..),
                             hSetBuffering, BufferMode(..), stdout)
 import System.Exit         (ExitCode(..))
-import System.Time         (ClockTime, getClockTime)
+import Data.Time.Clock        -- (ClockTime, getClockTime)
 import Control.Concurrent  (threadDelay)
-import Control.Exception   (catch, SomeException(..), bracket)
+import qualified Control.Exception as Exc  (catch,  bracket)
+import Control.Exception (SomeException(..))
 
 #ifdef CMDLINELOOP
 import System.Posix.Process (executeFile)
@@ -145,7 +145,7 @@ multiMain ds = do
       Just d  -> chooseRender opts d
 
 #ifdef CMDLINELOOP
-waitForChange :: Maybe ClockTime -> DiagramOpts -> String -> [String] -> IO ()
+waitForChange :: Maybe UTCTime -> DiagramOpts -> String -> [String] -> IO ()
 waitForChange lastAttempt opts prog args = do
     hSetBuffering stdout NoBuffering
     go lastAttempt
@@ -165,7 +165,7 @@ waitForChange lastAttempt opts prog args = do
 --   of this attempt.  Otherwise (if nothing has changed since the
 --   last attempt), return @Nothing@.  Also return a Bool saying
 --   whether a successful recompilation happened.
-recompile :: Maybe ClockTime -> String -> Maybe String -> IO (Bool, Maybe ClockTime)
+recompile :: Maybe UTCTime -> String -> Maybe String -> IO (Bool, Maybe UTCTime)
 recompile lastAttempt prog mSrc = do
   let errFile = prog ++ ".errors"
       srcFile = fromMaybe (prog ++ ".hs") mSrc
@@ -174,7 +174,7 @@ recompile lastAttempt prog mSrc = do
   if (srcT > binT)
     then do
       putStr "Recompiling..."
-      status <- bracket (openFile errFile WriteMode) hClose $ \h ->
+      status <- Exc.bracket (openFile errFile WriteMode) hClose $ \h ->
         waitForProcess =<< runProcess "ghc" ["--make", srcFile]
                            Nothing Nothing Nothing Nothing (Just h)
 
@@ -182,11 +182,11 @@ recompile lastAttempt prog mSrc = do
         then putStrLn "" >> putStrLn (replicate 75 '-') >> readFile errFile >>= putStr
         else putStrLn "done."
 
-      curTime <- getClockTime
+      curTime <- getCurrentTime
       return (status == ExitSuccess, Just curTime)
 
     else return (False, Nothing)
 
- where getModTime f = catch (Just <$> getModificationTime f)
+ where getModTime f = Exc.catch (Just <$> getModificationTime f)
                             (\(SomeException _) -> return Nothing)
 #endif


### PR DESCRIPTION
Trival evasion of Prelude.catch.  getModificationTime seems to have changed return type so I adjusted to use the time package instead of old-time. 
