### PR TITLE
Apply frozen transformations with <g> element.

### DIFF
--- a/diagrams-svg.cabal
+++ b/diagrams-svg.cabal
@@ -38,6 +38,7 @@ Library
                      , colour
                      , diagrams-core >= 0.6   && < 0.7
                      , diagrams-lib  >= 0.6   && < 0.7
+                     , monoid-extras >= 0.2   && < 0.3
                      , blaze-svg     >= 0.3.3
                      , cmdargs       >= 0.6   && < 0.11
                      , split         >= 0.1.2 && < 0.3

--- a/src/Graphics/Rendering/SVG.hs
+++ b/src/Graphics/Rendering/SVG.hs
@@ -6,6 +6,7 @@ module Graphics.Rendering.SVG
     , renderClipPathId
     , renderText
     , renderStyles
+    , renderTransform
     ) where
 
 -- from base
@@ -73,6 +74,11 @@ getMatrix t = (a1,a2,b1,b2,c1,c2)
   (unr2 -> (a1,a2)) = apply t unitX
   (unr2 -> (b1,b2)) = apply t unitY
   (unr2 -> (c1,c2)) = transl t
+
+-- Apply a transformation to some already-rendered SVG.
+renderTransform :: Transformation R2 -> S.Svg -> S.Svg
+renderTransform t svg = S.g svg ! (A.transform $ S.matrix a1 a2 b1 b2 c1 c2)
+  where (a1,a2,b1,b2,c1,c2) = getMatrix t
 
 renderStyles :: forall v. Style v -> S.Attribute
 renderStyles s = mconcat . map ($ s) $


### PR DESCRIPTION
Instead of applying both non-frozen and frozen transformations to
primitives before rendering them, only apply the non-frozen
transformation when rendering, and then wrap the rendered SVG in a <g>
element to apply the frozen transformation.  Then the
attributes (e.g. line width) are appropriately transformed.

This breaks the "clip" backend test.

(Should fix issues #19 and #24.)
