### PR TITLE
Added approximation of text alignment. Better then nothing...

### DIFF
--- a/src/Graphics/Rendering/SVG.hs
+++ b/src/Graphics/Rendering/SVG.hs
@@ -83,7 +83,6 @@ renderText (Text tr tAlign str) =
     ! A.stroke "none" $
       S.toMarkup str
  where
-  -- TextAlignment = BaselineText | BoxAlignedText Double Double
   vAlign = case tAlign of
              BaselineText -> "alphabetic"
              BoxAlignedText _ h -> case h of -- A mere approximation


### PR DESCRIPTION
This should be a first approach to issue #17.

I used the SVG standard sections on [text-anchors](http://www.w3.org/TR/SVG/text.html#TextAnchorProperty) and [baseline alignment](http://www.w3.org/TR/SVG/text.html#BaselineAlignmentProperties) to find what should be closest. I could not find properties to modify the alignments in a free manner as given by `BoxAlignedText`.

While I looked at the [user manual](http://projects.haskell.org/diagrams/doc/manual.html#text) I noticed that according to [documentation](http://hackage.haskell.org/packages/archive/diagrams-lib/0.7/doc/html/Diagrams-TwoD-Text.html#v:alignedText) shouldn't the `(0.7,0.5)` text displayed in the manual be right aligned instead of left aligned since 1 means right and 0 means left? Or am I misunderstanding the semantics here?
