### PR TITLE
Should fix issue 43 SVG backend doesn't fill loops if they occur in the same subtree as a line, along with fill/lib

### DIFF
--- a/src/Graphics/Rendering/SVG.hs
+++ b/src/Graphics/Rendering/SVG.hs
@@ -124,12 +124,10 @@ renderTransform t svg =
     where (a1,a2,b1,b2,c1,c2) = getMatrix t
           i = (a1,a2,b1,b2,c1,c2) == (1,0,0,1,0,0)
 
-renderStyles :: Bool -> Style v -> S.Attribute
-renderStyles ignoreFill s = mconcat . map ($ s) $
+renderStyles :: Style v -> S.Attribute
+renderStyles s = mconcat . map ($ s) $
   [ renderLineColor
-  , if ignoreFill
-      then const (renderAttr A.fillOpacity (Just (0 :: Double)))
-      else renderFillColor
+  , renderFillColor
   , renderLineWidth
   , renderLineCap
   , renderLineJoin


### PR DESCRIPTION
This goes with its companion branch of SVG
Please have a careful look before merging and only merge with fill/lib
