### PR TITLE
Allows us to write `Diagram B` instead of `Diagram B V2 Double/Float/Whatever` in diagrams programs

### DIFF
--- a/src/Diagrams/Backend/SVG.hs
+++ b/src/Diagrams/Backend/SVG.hs
@@ -90,7 +90,6 @@
 module Diagrams.Backend.SVG
   ( SVG(..) -- rendering token
   , B
-  , Figure
   , Options(..), sizeSpec, svgDefinitions -- for rendering options specific to SVG
   , SVGFloat
 
@@ -123,7 +122,7 @@ import           Control.Lens                 hiding (transform, ( # ))
 
 -- from diagrams-core
 import           Diagrams.Core.Compile
-import           Diagrams.Core.Types          (Figure, Annotation (..))
+import           Diagrams.Core.Types          (Annotation (..))
 
 -- from diagrams-lib
 import           Diagrams.Prelude             hiding (view, size)
@@ -153,7 +152,8 @@ data SVG = SVG
 
 type B = SVG
 
-type instance Figure SVG = Diagram SVG V2 Double
+type instance V SVG = V2
+type instance N SVG = Double
 
 data SvgRenderState = SvgRenderState { _clipPathId  :: Int
                                      , _fillGradId  :: Int
@@ -361,14 +361,14 @@ instance SVGFloat n => Renderable (DImage n Embedded) SVG where
 
 -- | Render a diagram as an SVG, writing to the specified output file
 --   and using the requested size.
-renderSVG :: SVGFloat n => FilePath -> SizeSpec2D n -> Diagram SVG V2 n -> IO ()
+renderSVG :: SVGFloat n => FilePath -> SizeSpec2D n -> QDiagram SVG V2 n Any -> IO ()
 renderSVG outFile szSpec
   = BS.writeFile outFile
   . renderSvg
   . renderDia SVG (SVGOptions szSpec Nothing)
 
 -- | Render a diagram as a pretty printed SVG.
-renderPretty :: SVGFloat n => FilePath -> SizeSpec2D n -> Diagram SVG V2 n -> IO ()
+renderPretty :: SVGFloat n => FilePath -> SizeSpec2D n -> QDiagram SVG V2 n Any -> IO ()
 renderPretty outFile szSpec
   = writeFile outFile
   . Pretty.renderSvg
@@ -379,7 +379,7 @@ renderPretty outFile szSpec
 data Img = Img !Char !BS.ByteString deriving Typeable
 
 -- | Load images (JPG/PNG/...) in a SVG specific way.
-loadImageSVG :: SVGFloat n => FilePath -> IO (Diagram SVG V2 n)
+loadImageSVG :: SVGFloat n => FilePath -> IO (QDiagram SVG V2 n Any)
 loadImageSVG fp = do
     raw <- SBS.readFile fp
     dyn <- eIO $ decodeImage raw

--- a/src/Diagrams/Backend/SVG/CmdLine.hs
+++ b/src/Diagrams/Backend/SVG/CmdLine.hs
@@ -69,7 +69,6 @@ module Diagrams.Backend.SVG.CmdLine
 
        , SVG
        , B
-       , Figure
        ) where
 
 import           Diagrams.Backend.CmdLine
@@ -177,7 +176,7 @@ getModuleTime = getClockTime
 -- $ ./MyDiagram -o image.svg -w 400
 -- @
 
-defaultMain :: SVGFloat n => Diagram SVG V2 n -> IO ()
+defaultMain :: SVGFloat n => QDiagram SVG V2 n Any -> IO ()
 defaultMain = mainWith
 
 newtype PrettyOpt = PrettyOpt {isPretty :: Bool}
@@ -190,20 +189,20 @@ prettyOpt = PrettyOpt <$> switch (long "pretty"
 instance Parseable PrettyOpt where
   parser = prettyOpt
 
-instance SVGFloat n => Mainable (Diagram SVG V2 n) where
+instance SVGFloat n => Mainable (QDiagram SVG V2 n Any) where
 #ifdef CMDLINELOOP
-    type MainOpts (Diagram SVG V2 n) = (DiagramOpts, DiagramLoopOpts, PrettyOpt)
+    type MainOpts (QDiagram SVG V2 n Any) = (DiagramOpts, DiagramLoopOpts, PrettyOpt) 
 
     mainRender (opts, loopOpts, pretty) d = do
         chooseRender opts pretty d
         when (loopOpts^.loop) (waitForChange Nothing loopOpts)
 #else
-    type MainOpts (Diagram SVG R2) = (DiagramOpts, PrettyOpt)
+    type MainOpts (QDiagram SVG V2 n Any) = (DiagramOpts, PrettyOpt)
 
     mainRender (opts, pretty) = chooseRender opts pretty
 #endif
 
-chooseRender :: SVGFloat n => DiagramOpts -> PrettyOpt -> Diagram SVG V2 n -> IO ()
+chooseRender :: SVGFloat n => DiagramOpts -> PrettyOpt -> QDiagram SVG V2 n Any -> IO ()
 chooseRender opts pretty d =
   case splitOn "." (opts^.output) of
     [""] -> putStrLn "No output file given."
@@ -240,12 +239,12 @@ chooseRender opts pretty d =
 -- $ ./MultiTest --selection bar -o Bar.eps -w 200
 -- @
 
-multiMain :: SVGFloat n => [(String, Diagram SVG V2 n)] -> IO ()
+multiMain :: SVGFloat n => [(String, QDiagram SVG V2 n Any)] -> IO ()
 multiMain = mainWith
 
-instance SVGFloat n => Mainable [(String,Diagram SVG V2 n)] where
-    type MainOpts [(String,Diagram SVG V2 n)]
-        = (MainOpts (Diagram SVG V2 n), DiagramMultiOpts)
+instance SVGFloat n => Mainable [(String,QDiagram SVG V2 n Any)] where
+    type MainOpts [(String,QDiagram SVG V2 n Any)]
+        = (MainOpts (QDiagram SVG V2 n Any), DiagramMultiOpts)
 
     mainRender = defaultMultiMainRender
 


### PR DESCRIPTION
Currently the linear changes has made the `B` token less useful since the type `Diagram B V2 n` the n depends on `B` the backend.
This provides the ability to switch backends simply by changing the import by using `Diagram B` instead of `Diagram B V2 Double` e.g.
- Companion branch in core
