### PR TITLE
Bump lens upper version bounds

### DIFF
--- a/diagrams-svg.cabal
+++ b/diagrams-svg.cabal
@@ -58,7 +58,7 @@ Library
                      , split         >= 0.1.2 && < 0.3
                      , time
                      , containers >= 0.3 && < 0.6
-                     , lens >= 4.0 && < 4.5
+                     , lens >= 4.0 && < 4.6
                      , hashable >= 1.1 && < 1.3
                      , optparse-applicative >= 0.10 && < 0.12
   if impl(ghc < 7.6)


### PR DESCRIPTION
Allow `diagrams-svg` to use the latest version of `lens` (4.5).
