### PR TITLE
Lucid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
+diagrams-svg [![Hackage](https://img.shields.io/hackage/v/diagrams-svg.svg?style=flat)](https://hackage.haskell.org/package/diagrams-svg)
+------------
 [![Build Status](https://travis-ci.org/diagrams/diagrams-svg.png?branch=master)](http://travis-ci.org/diagrams/diagrams-svg)
+
 
 _diagrams-svg_ is a an SVG backend for [diagrams]. Diagrams is a powerful,
 flexible, declarative domain-specific language for creating vector graphics,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-diagrams-svg [![Hackage](https://img.shields.io/hackage/v/diagrams-svg.svg?style=flat)](https://hackage.haskell.org/package/diagrams-svg)
+diagrams-svg [![Hackage](https://img.shields.io/hackage/v/diagrams-svg.svg?style=flat)](https://hackage.haskell.org/package/diagrams-svg) [![Build Status](https://travis-ci.org/diagrams/diagrams-svg.png?branch=master)](http://travis-ci.org/diagrams/diagrams-svg)
 ------------
-[![Build Status](https://travis-ci.org/diagrams/diagrams-svg.png?branch=master)](http://travis-ci.org/diagrams/diagrams-svg)
 
 
 _diagrams-svg_ is a an SVG backend for [diagrams]. Diagrams is a powerful,

--- a/diagrams-svg.cabal
+++ b/diagrams-svg.cabal
@@ -54,7 +54,7 @@ Library
                      , monoid-extras >= 0.3   && < 0.4
                      , blaze-svg     >= 0.3.3
                      , blaze-markup  >= 0.5   && < 0.7
-                     , lucid-svg     >= 0.1   && < 0.2
+                     , lucid-svg     >= 0.2   && < 0.3
                      , text          >= 1.2   && < 1.3
                      , JuicyPixels   >= 3.1.5 && < 3.3
                      , split         >= 0.1.2 && < 0.3

--- a/diagrams-svg.cabal
+++ b/diagrams-svg.cabal
@@ -40,27 +40,27 @@ Library
                        Diagrams.Backend.SVG.CmdLine
   Other-modules:       Graphics.Rendering.SVG
   Hs-source-dirs:      src
-  Build-depends:       base          >= 4.3   && < 4.8
+  Build-depends:       base                 >= 4.3   && < 4.8
                      , old-time
                      , process
                      , directory
                      , filepath
-                     , mtl           >= 1     && < 2.3
-                     , bytestring    >= 0.9   && < 1.0
-                     , base64-bytestring >= 1 && < 1.1
+                     , mtl                  >= 1     && < 2.3
+                     , bytestring           >= 0.9   && < 1.0
+                     , base64-bytestring    >= 1     && < 1.1
                      , colour
-                     , diagrams-core >= 1.2   && < 1.3
-                     , diagrams-lib  >= 1.2   && < 1.3
-                     , monoid-extras >= 0.3   && < 0.4
-                     , lucid-svg     >= 0.2   && < 0.3
-                     , text          >= 1.2   && < 1.3
-                     , JuicyPixels   >= 3.1.5 && < 3.3
-                     , split         >= 0.1.2 && < 0.3
+                     , diagrams-core        >= 1.2   && < 1.3
+                     , diagrams-lib         >= 1.2   && < 1.3
+                     , monoid-extras        >= 0.3   && < 0.4
+                     , lucid-svg            >= 0.2.1 && < 0.3
+                     , text                 >= 1.2   && < 1.3
+                     , JuicyPixels          >= 3.1.5 && < 3.3
+                     , split                >= 0.1.2 && < 0.3
                      , time
-                     , containers >= 0.3 && < 0.6
-                     , lens >= 4.0 && < 4.8
-                     , hashable >= 1.1 && < 1.3
-                     , optparse-applicative >= 0.10 && < 0.12
+                     , containers           >= 0.3   && < 0.6
+                     , lens                 >= 4.0   && < 4.8
+                     , hashable             >= 1.1   && < 1.3
+                     , optparse-applicative >= 0.10  && < 0.12
   if impl(ghc < 7.6)
     build-depends:     ghc-prim
 

--- a/diagrams-svg.cabal
+++ b/diagrams-svg.cabal
@@ -54,6 +54,8 @@ Library
                      , monoid-extras >= 0.3   && < 0.4
                      , blaze-svg     >= 0.3.3
                      , blaze-markup  >= 0.5   && < 0.7
+                     , lucid-svg     >= 0.1   && < 0.2
+                     , text          >= 1.2   && < 1.3
                      , JuicyPixels   >= 3.1.5 && < 3.3
                      , split         >= 0.1.2 && < 0.3
                      , time

--- a/diagrams-svg.cabal
+++ b/diagrams-svg.cabal
@@ -52,7 +52,7 @@ Library
                      , diagrams-core        >= 1.2   && < 1.3
                      , diagrams-lib         >= 1.2   && < 1.3
                      , monoid-extras        >= 0.3   && < 0.4
-                     , lucid-svg            >= 0.3   && < 0.4
+                     , lucid-svg            >= 0.4   && < 0.5
                      , text                 >= 1.2   && < 1.3
                      , JuicyPixels          >= 3.1.5 && < 3.3
                      , split                >= 0.1.2 && < 0.3

--- a/diagrams-svg.cabal
+++ b/diagrams-svg.cabal
@@ -52,8 +52,6 @@ Library
                      , diagrams-core >= 1.2   && < 1.3
                      , diagrams-lib  >= 1.2   && < 1.3
                      , monoid-extras >= 0.3   && < 0.4
-                     , blaze-svg     >= 0.3.3
-                     , blaze-markup  >= 0.5   && < 0.7
                      , lucid-svg     >= 0.2   && < 0.3
                      , text          >= 1.2   && < 1.3
                      , JuicyPixels   >= 3.1.5 && < 3.3

--- a/diagrams-svg.cabal
+++ b/diagrams-svg.cabal
@@ -52,7 +52,7 @@ Library
                      , diagrams-core        >= 1.2   && < 1.3
                      , diagrams-lib         >= 1.2   && < 1.3
                      , monoid-extras        >= 0.3   && < 0.4
-                     , lucid-svg            >= 0.2.1 && < 0.3
+                     , lucid-svg            >= 0.3   && < 0.4
                      , text                 >= 1.2   && < 1.3
                      , JuicyPixels          >= 3.1.5 && < 3.3
                      , split                >= 0.1.2 && < 0.3

--- a/examples/Pentaflake.lhs
+++ b/examples/Pentaflake.lhs
@@ -22,7 +22,7 @@ pentaflakes around the central one.
 > pentaflake n = appends (p' # fc (colors !! (n-1)))
 >                        (zip vs (repeat (rotateBy (1/2) p')))
 >   where vs = take 5 . iterate (rotateBy (1/5))
->                     . (if odd n then negateV else id) $ unitY
+>                     . (if odd n then negated else id) $ unitY
 >         p' = pentaflake (n-1)
 > 
 > pentaflake' n = pentaflake n # fc (colors !! n)
@@ -31,5 +31,6 @@ An order-4 pentaflake looks nice.  Of course there's an exponential
 blowup in the number of primitives, so generating higher-order
 pentaflakes can take a long time!
 
+> example :: Diagram B
 > example = pad 1.1 $ pentaflake' 4
 > main = defaultMain (pad 1.1 example)

--- a/src/Diagrams/Backend/SVG.hs
+++ b/src/Diagrams/Backend/SVG.hs
@@ -100,8 +100,9 @@ module Diagrams.Backend.SVG
 -- from JuicyPixels
 import           Codec.Picture
 import           Codec.Picture.Types(dynamicMap)
--- for testing
+
 import           Data.Foldable                as F (foldMap)
+import           Data.Text.Lazy.IO            as LT
 import           Data.Tree
 
 -- from base
@@ -294,10 +295,9 @@ renderSVG outFile spec
 -- | Render a diagram as a pretty printed SVG.
 renderPretty :: SVGFloat n => FilePath -> SizeSpec V2 n -> QDiagram SVG V2 n Any -> IO ()
 renderPretty outFile spec
-  = undefined
-  -- = writeFile outFile
-  -- . Pretty.renderSvg
-  -- . renderDia SVG (SVGOptions spec Nothing)
+  = LT.writeFile outFile
+  . prettyText
+  . renderDia SVG (SVGOptions spec [])
 
 data Img = Img !Char !BS.ByteString deriving Typeable
 

--- a/src/Diagrams/Backend/SVG.hs
+++ b/src/Diagrams/Backend/SVG.hs
@@ -235,6 +235,11 @@ toRender = fromRTree
             let R r =  foldMap fromRTree rs
             svg <- r
             return $ a_ [xlinkHref_ $ toText uri] svg
+      fromRTree (Node (RAnnot (OpacityGroup o)) rs)
+        = R $ do
+            let R r =  foldMap fromRTree rs
+            svg <- r
+            return $ g_ [opacity_ $ toText o] svg
       fromRTree (Node (RPrim p) _) = render SVG p
       fromRTree (Node (RStyle sty) ts)
         = R $ do

--- a/src/Diagrams/Backend/SVG.hs
+++ b/src/Diagrams/Backend/SVG.hs
@@ -132,14 +132,6 @@ import           Diagrams.TwoD.Path           (Clip (Clip))
 import           Diagrams.TwoD.Text
 
 import           Lucid.Svg
--- from blaze-svg
-import           Text.Blaze.Internal          (ChoiceString (..), MarkupM (..),
-                                               StaticString (..))
-import           Text.Blaze.Svg.Renderer.Utf8 (renderSvg)
-import           Text.Blaze.Svg11             ((!))
-import qualified Text.Blaze.Svg11             as S
-import           Text.Blaze.Svg11.Attributes  (xlinkHref)
-import qualified Text.Blaze.Svg.Renderer.Pretty as Pretty
 
 -- from this package
 import qualified Graphics.Rendering.SVG       as R
@@ -274,66 +266,6 @@ setSVGDefs o d = o {_svgDefinitions = d}
 
 svgDefinitions :: SVGFloat n => Lens' (Options SVG V2 n) [Attribute]
 svgDefinitions = lens getSVGDefs setSVGDefs
-
--- instance (Hashable n, SVGFloat n) => Hashable (Options SVG V2 n) where
---   hashWithSalt s (SVGOptions sz defs) =
---     s `hashWithSalt` sz `hashWithSalt` defs
-
-instance Hashable StaticString where
-  hashWithSalt s (StaticString dl bs txt)
-    = s `hashWithSalt` dl [] `hashWithSalt` bs `hashWithSalt` txt
-
-deriving instance Generic ChoiceString
-
-instance Hashable ChoiceString
-
-instance Hashable (MarkupM a) where
-  hashWithSalt s (Parent w x y z) =
-    s          `hashWithSalt`
-    (0 :: Int) `hashWithSalt`
-    w          `hashWithSalt`
-    x          `hashWithSalt`
-    y          `hashWithSalt`
-    z
-  hashWithSalt s (CustomParent cs m) =
-    s          `hashWithSalt`
-    (1 :: Int) `hashWithSalt`
-    cs         `hashWithSalt`
-    m
-  hashWithSalt s (Leaf s1 s2 s3) =
-    s          `hashWithSalt`
-    (2 :: Int) `hashWithSalt`
-    s1         `hashWithSalt`
-    s2         `hashWithSalt`
-    s3
-  hashWithSalt s (CustomLeaf cs b) =
-    s          `hashWithSalt`
-    (3 :: Int) `hashWithSalt`
-    cs         `hashWithSalt`
-    b
-  hashWithSalt s (Content cs) =
-    s          `hashWithSalt`
-    (4 :: Int) `hashWithSalt`
-    cs
-  hashWithSalt s (Append m1 m2) =
-    s          `hashWithSalt`
-    (5 :: Int) `hashWithSalt`
-    m1         `hashWithSalt`
-    m2
-  hashWithSalt s (AddAttribute s1 s2 s3 m) =
-    s          `hashWithSalt`
-    (6 :: Int) `hashWithSalt`
-    s1         `hashWithSalt`
-    s2         `hashWithSalt`
-    s3         `hashWithSalt`
-    m
-  hashWithSalt s (AddCustomAttribute s1 s2 m) =
-    s          `hashWithSalt`
-    (7 :: Int) `hashWithSalt`
-    s1         `hashWithSalt`
-    s2         `hashWithSalt`
-    m
-  hashWithSalt s Empty = s `hashWithSalt` (8 :: Int)
 
 instance SVGFloat n => Renderable (Path V2 n) SVG where
   render _ = R . return . R.renderPath

--- a/src/Diagrams/Backend/SVG.hs
+++ b/src/Diagrams/Backend/SVG.hs
@@ -1,21 +1,20 @@
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE DeriveDataTypeable    #-}
-{-# LANGUAGE DeriveGeneric         #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE StandaloneDeriving    #-}
-{-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeSynonymInstances  #-}
-{-# LANGUAGE NondecreasingIndentation #-}
-{-# LANGUAGE UndecidableInstances #-}
--- UndecidableInstances needed for ghc < 707
+{-# LANGUAGE ConstraintKinds            #-}
+{-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeSynonymInstances       #-}
+{-# LANGUAGE NondecreasingIndentation   #-}
+{-# LANGUAGE UndecidableInstances       #-} -- UndecidableInstances needed for ghc < 707
+{-# LANGUAGE GADTs                      #-}
 
-{-# LANGUAGE GADTs #-}
-
-{-# OPTIONS_GHC -fno-warn-orphans  #-}
+{-# OPTIONS_GHC -fno-warn-orphans       #-}
 
 ----------------------------------------------------------------------------
 -- |
@@ -330,3 +329,8 @@ instance SVGFloat n => Renderable (DImage n (Native Img)) SVG where
           'P' -> return "image/png"
           _   -> fail   "Unknown mime type while rendering image"
     return $ R.renderDImage di $ R.dataUri mime d
+
+deriving instance Hashable Attribute
+
+instance (Hashable n, SVGFloat n) => Hashable (Options SVG V2 n) where
+  hashWithSalt s  (SVGOptions sz defs) = s `hashWithSalt` sz `hashWithSalt` defs

--- a/src/Diagrams/Backend/SVG.hs
+++ b/src/Diagrams/Backend/SVG.hs
@@ -338,8 +338,8 @@ instance Hashable (MarkupM a) where
 instance SVGFloat n => Renderable (Path V2 n) SVG where
   render _ = R . return . R.renderPath
 
--- instance SVGFloat n => Renderable (Text n) SVG where
---   render _ = R . return . R.renderText
+instance SVGFloat n => Renderable (Text n) SVG where
+  render _ = R . return . R.renderText 
 
 instance SVGFloat n => Renderable (DImage n Embedded) SVG where
   render _ = R . return . R.renderDImageEmb

--- a/src/Diagrams/Backend/SVG.hs
+++ b/src/Diagrams/Backend/SVG.hs
@@ -108,7 +108,6 @@ import           Data.Tree
 -- from base
 import           Control.Monad.State
 import           Data.Typeable
-import           GHC.Generics                 (Generic)
 
 -- from hashable
 import           Data.Hashable                (Hashable (..))
@@ -161,7 +160,7 @@ initialSvgRenderState = SvgRenderState 0 0 1
 -- | Monad to keep track of state when rendering an SVG.
 --   Currently just keeps a monotonically increasing counter
 --   for assiging a unique clip path ID.
-type SvgRenderM = State SvgRenderState (SvgM)
+type SvgRenderM = State SvgRenderState SvgM
 
 instance SVGFloat n => Monoid (Render SVG V2 n) where
   mempty  = R $ return mempty
@@ -277,7 +276,7 @@ instance SVGFloat n => Renderable (Path V2 n) SVG where
   render _ = R . return . R.renderPath
 
 instance SVGFloat n => Renderable (Text n) SVG where
-  render _ = R . return . R.renderText 
+  render _ = R . return . R.renderText
 
 instance SVGFloat n => Renderable (DImage n Embedded) SVG where
   render _ = R . return . R.renderDImageEmb

--- a/src/Diagrams/Backend/SVG/CmdLine.hs
+++ b/src/Diagrams/Backend/SVG/CmdLine.hs
@@ -81,7 +81,8 @@ import qualified Options.Applicative            as O ((<>))
 
 import qualified Data.ByteString.Lazy           as BS
 import qualified Text.Blaze.Svg.Renderer.Pretty as Pretty
-import           Text.Blaze.Svg.Renderer.Utf8   (renderSvg)
+
+import           Lucid.Svg                      (renderBS)
 
 import           Data.List.Split
 
@@ -172,10 +173,11 @@ chooseRender opts pretty d =
     [""] -> putStrLn "No output file given."
     ps | last ps `elem` ["svg"] -> do
            let szSpec = fromIntegral <$> mkSizeSpec2D (opts^.width) (opts^.height)
-               build  = renderDia SVG (SVGOptions szSpec Nothing) d
-           if isPretty pretty
-             then writeFile (opts^.output) (Pretty.renderSvg build)
-             else BS.writeFile (opts^.output) (renderSvg build)
+               build  = renderDia SVG (SVGOptions szSpec []) d
+           -- if isPretty pretty
+           --   then writeFile (opts^.output) (Pretty.renderSvg build)
+           --   else BS.writeFile (opts^.output) (renderBS build)
+           BS.writeFile (opts^.output) (renderBS build)
        | otherwise -> putStrLn $ "Unknown file type: " ++ last ps
 
 -- | @multiMain@ is like 'defaultMain', except instead of a single

--- a/src/Diagrams/Backend/SVG/CmdLine.hs
+++ b/src/Diagrams/Backend/SVG/CmdLine.hs
@@ -80,7 +80,6 @@ import           Options.Applicative            hiding ((<>))
 import qualified Options.Applicative            as O ((<>))
 
 import qualified Data.ByteString.Lazy           as BS
-import qualified Text.Blaze.Svg.Renderer.Pretty as Pretty
 
 import           Lucid.Svg                      (renderBS)
 

--- a/src/Diagrams/Backend/SVG/CmdLine.hs
+++ b/src/Diagrams/Backend/SVG/CmdLine.hs
@@ -80,8 +80,9 @@ import           Options.Applicative            hiding ((<>))
 import qualified Options.Applicative            as O ((<>))
 
 import qualified Data.ByteString.Lazy           as BS
+import qualified Data.Text.Lazy.IO              as LT
 
-import           Lucid.Svg                      (renderBS)
+import           Lucid.Svg                      (renderBS, prettyText)
 
 import           Data.List.Split
 
@@ -173,10 +174,9 @@ chooseRender opts pretty d =
     ps | last ps `elem` ["svg"] -> do
            let szSpec = fromIntegral <$> mkSizeSpec2D (opts^.width) (opts^.height)
                build  = renderDia SVG (SVGOptions szSpec []) d
-           -- if isPretty pretty
-           --   then writeFile (opts^.output) (Pretty.renderSvg build)
-           --   else BS.writeFile (opts^.output) (renderBS build)
-           BS.writeFile (opts^.output) (renderBS build)
+           if isPretty pretty
+             then LT.writeFile (opts^.output) (prettyText build)
+             else BS.writeFile (opts^.output) (renderBS build)
        | otherwise -> putStrLn $ "Unknown file type: " ++ last ps
 
 -- | @multiMain@ is like 'defaultMain', except instead of a single

--- a/src/Graphics/Rendering/SVG.hs
+++ b/src/Graphics/Rendering/SVG.hs
@@ -121,7 +121,7 @@ renderSeg (Cubic  (V2 x0 y0)
 
 renderClip :: SVGFloat n => Path V2 n -> Int -> SvgM -> SvgM
 renderClip p ident svg =
-  g_  [clipPath_ $ ("url(#" <> clipPathId ident <> ")")] $ do
+  g_  [clip_path_ $ ("url(#" <> clipPathId ident <> ")")] $ do
     clipPath_ [id_ (clipPathId ident)] (renderPath p)
     svg
   where clipPathId i = "myClip" <> (toText i)

--- a/src/Graphics/Rendering/SVG.hs
+++ b/src/Graphics/Rendering/SVG.hs
@@ -46,12 +46,16 @@ import           Control.Lens                hiding (transform)
 import           Diagrams.Core.Transform     (matrixHomRep)
 
 -- from diagrams-lib
-import           Diagrams.Prelude            hiding (Attribute, Render, (<>))
+import           Diagrams.Prelude            hiding (Attribute, Render, with, (<>))
 import           Diagrams.TwoD.Path          (getFillRule)
 import           Diagrams.TwoD.Text
 
+import qualified Data.Text                   as T
+import           Data.Monoid
+import           Lucid.Svg                   hiding (renderText)
+
 -- from blaze-svg
-import           Text.Blaze.Svg11            (cr, hr, lr, m, mkPath, vr, z, (!))
+import           Text.Blaze.Svg11            (cr, hr, lr, m, mkPath, vr, (!))
 import qualified Text.Blaze.Svg11            as S
 import qualified Text.Blaze.Svg11.Attributes as A
 import qualified Data.ByteString.Base64.Lazy as BS64
@@ -66,11 +70,24 @@ type SVGFloat n = (Show n, TypeableFloat n, S.ToValue n)
 --   showFFloat :: RealFloat a => Maybe Int -> a -> ShowS
 -- or something similar for all numbers so we need TypeableFloat constraint.
 
+toText :: Show a => a -> T.Text
+toText = T.pack . show
+
 getNumAttr :: AttributeClass (a n) => (a n -> t) -> Style v n -> Maybe t
 getNumAttr f = (f <$>) . getAttr
 
 -- | @svgHeader w h defs s@: @w@ width, @h@ height,
 --   @defs@ global definitions for defs sections, @s@ actual SVG content.
+svgHeader' :: SVGFloat n => n -> n -> [Attribute] -> Svg () -> Svg ()
+svgHeader' w h defines s =  doctype_ <> with (svg11_ (g_ (defs_ defines s)))
+  [ version_ "1.1"
+  , width_    (toText w)
+  , height_   (toText h)
+  , fontSize_ "1"
+  , viewBox_ (toText . unwords $ map show ([0, 0, round w, round h] :: [Int]))
+  , stroke_ "rgb(0,0,0)"
+  , strokeOpacity_ "1" ]
+
 svgHeader :: SVGFloat n => n -> n -> Maybe S.Svg -> S.Svg -> S.Svg
 svgHeader w h_ defines s =  S.docTypeSvg
   ! A.version "1.1"
@@ -82,10 +99,28 @@ svgHeader w h_ defines s =  S.docTypeSvg
   ! A.strokeOpacity "1"
   $ F.mapM_ S.defs defines >> S.g s
 
+renderPath' :: SVGFloat n => Path V2 n -> Svg ()
+renderPath' trs  = path_  [d_ makePath]
+  where
+    makePath = T.concat $ map renderTrail' (op Path trs)
+
 renderPath :: SVGFloat n => Path V2 n -> S.Svg
 renderPath trs  = S.path ! A.d makePath
   where
     makePath = mkPath $ mapM_ renderTrail (op Path trs)
+
+renderTrail' :: SVGFloat n => Located (Trail V2 n) -> T.Text
+renderTrail' (viewLoc -> (P (V2 x y), t)) = mR x y <> withTrail renderLine renderLoop t
+  where
+    renderLine = T.concat . map renderSeg' . lineSegments
+    renderLoop lp =
+      case loopSegments lp of
+        -- let 'z' handle the last segment if it is linear
+        (segs, Linear _) -> T.concat $ map renderSeg' segs
+
+        -- otherwise we have to emit it explicitly
+        _ -> T.concat $ map renderSeg' (lineSegments . cutLoop $ lp)
+      <> z
 
 renderTrail :: SVGFloat n => Located (Trail V2 n) -> S.Path
 renderTrail (viewLoc -> (P (V2 x y), t)) = m x y >> withTrail renderLine renderLoop t
@@ -98,7 +133,15 @@ renderTrail (viewLoc -> (P (V2 x y), t)) = m x y >> withTrail renderLine renderL
 
         -- otherwise we have to emit it explicitly
         _ -> mapM_ renderSeg (lineSegments . cutLoop $ lp)
-      z
+      S.z
+
+renderSeg' :: SVGFloat n => Segment Closed V2 n -> T.Text
+renderSeg' (Linear (OffsetClosed (V2 x 0))) = hR x
+renderSeg' (Linear (OffsetClosed (V2 0 y))) = vR y
+renderSeg' (Linear (OffsetClosed (V2 x y))) = lR x y
+renderSeg' (Cubic  (V2 x0 y0)
+                  (V2 x1 y1)
+                  (OffsetClosed (V2 x2 y2))) = cR x0 y0 x1 y1 x2 y2
 
 renderSeg :: SVGFloat n => Segment Closed V2 n -> S.Path
 renderSeg (Linear (OffsetClosed (V2 x 0))) = hr x
@@ -108,6 +151,13 @@ renderSeg (Cubic  (V2 x0 y0)
                   (V2 x1 y1)
                   (OffsetClosed (V2 x2 y2))) = cr x0 y0 x1 y1 x2 y2
 
+renderClip' :: SVGFloat n => Path V2 n -> Int -> Svg () -> Svg ()
+renderClip' p ident svg =
+  g_  [clipPath_ $ ("url(#" <> clipPathId ident <> ")")] $ do
+    clippath_ [id_ (clipPathId ident)] (renderPath' p)
+    svg
+  where clipPathId i = "myClip" <> (toText i)
+
 renderClip :: SVGFloat n => Path V2 n -> Int -> S.Svg -> S.Svg
 renderClip p id_ svg =
   S.g ! A.clipPath (S.toValue $ "url(#" ++ clipPathId id_ ++ ")") $ do
@@ -115,16 +165,44 @@ renderClip p id_ svg =
     svg
   where clipPathId i = "myClip" ++ show i
 
+renderStop' :: SVGFloat n => GradientStop n -> Svg ()
+renderStop' (GradientStop c v)
+  = stop_ [ stopColor_ (colorToRgbText c)
+          , offset_ (toText v)
+          , stopOpacity_ (toText $ colorToOpacity c) ]
+
 renderStop :: SVGFloat n => GradientStop n -> S.Svg
 renderStop (GradientStop c v)
   = S.stop ! A.stopColor (S.toValue (colorToRgbString c))
            ! A.offset (S.toValue (show v))
            ! A.stopOpacity (S.toValue (colorToOpacity c))
 
+spreadMethodText :: SpreadMethod -> T.Text
+spreadMethodText GradPad      = "pad"
+spreadMethodText GradReflect  = "reflect"
+spreadMethodText GradRepeat   = "repeat"
+
 spreadMethodStr :: SpreadMethod -> String
 spreadMethodStr GradPad      = "pad"
 spreadMethodStr GradReflect  = "reflect"
 spreadMethodStr GradRepeat   = "repeat"
+
+renderLinearGradient' :: SVGFloat n => LGradient n -> Int -> Svg ()
+renderLinearGradient' g i = linearGradient_
+    [ id_ (T.pack $ "gradient" ++ show i)
+    , x1_  (toText x1)
+    , y1_  (toText y1)
+    , x2_  (toText x2)
+    , y2_  (toText y2)
+    , gradientTransform_ mx
+    , gradientUnits_ "userSpaceOnUse"
+    , spreadMethod_ (spreadMethodText (g^.lGradSpreadMethod)) ]
+    ( foldMap renderStop' (g^.lGradStops) )
+  where
+    mx = matrix a1 a2 b1 b2 c1 c2
+    [[a1, a2], [b1, b2], [c1, c2]] = matrixHomRep (g^.lGradTrans)
+    P (V2 x1 y1) = g ^. lGradStart
+    P (V2 x2 y2) = g ^. lGradEnd
 
 renderLinearGradient :: SVGFloat n => LGradient n -> Int -> S.Svg
 renderLinearGradient g i = S.lineargradient
@@ -142,6 +220,35 @@ renderLinearGradient g i = S.lineargradient
     [[a1, a2], [b1, b2], [c1, c2]] = matrixHomRep (g^.lGradTrans)
     P (V2 x1 y1) = g ^. lGradStart
     P (V2 x2 y2) = g ^. lGradEnd
+
+renderRadialGradient' :: SVGFloat n => RGradient n -> Int -> Svg ()
+renderRadialGradient' g i = radialGradient_
+    [ id_ (T.pack $ "gradient" ++ show i)
+    , r_ (toText (g^.rGradRadius1))
+    , cx_ (toText cx')
+    , cy_ (toText cy')
+    , fx_ (toText fx')
+    , fy_ (toText fy')
+    , gradientTransform_ mx
+    , gradientUnits_ "userSpaceOnUse"
+    , spreadMethod_ (spreadMethodText (g^.rGradSpreadMethod)) ]
+    ( foldMap renderStop' ss )
+  where
+    mx = matrix a1 a2 b1 b2 c1 c2
+    [[a1, a2], [b1, b2], [c1, c2]] = matrixHomRep (g^.rGradTrans)
+    P (V2 cx' cy') = g ^. rGradCenter1
+    P (V2 fx' fy') = g ^. rGradCenter0 -- SVG's focal point is our inner center.
+
+    -- Adjust the stops so that the gradient begins at the perimeter of
+    -- the inner circle (center0, radius0) and ends at the outer circle.
+    r0 = g^.rGradRadius0
+    r1 = g^.rGradRadius1
+    stopFracs = r0 / r1 : map (\s -> (r0 + (s^.stopFraction) * (r1 - r0)) / r1)
+                (g^.rGradStops)
+    gradStops = case g^.rGradStops of
+      []       -> []
+      xs@(x:_) -> x : xs
+    ss = zipWith (\gs sf -> gs & stopFraction .~ sf ) gradStops stopFracs
 
 renderRadialGradient :: SVGFloat n => RGradient n -> Int -> S.Svg
 renderRadialGradient g i = S.radialgradient
@@ -173,6 +280,13 @@ renderRadialGradient g i = S.radialgradient
     ss = zipWith (\gs sf -> gs & stopFraction .~ sf ) gradStops stopFracs
 
 -- Create a gradient element so that it can be used as an attribute value for fill.
+renderFillTextureDefs' :: SVGFloat n => Int -> Style v n -> Svg ()
+renderFillTextureDefs' i s =
+  case getNumAttr getFillTexture s of
+    Just (LG g) -> renderLinearGradient' g i
+    Just (RG g) -> renderRadialGradient' g i
+    _           -> mempty
+
 renderFillTextureDefs :: SVGFloat n => Int -> Style v n -> S.Svg
 renderFillTextureDefs i s =
   case getNumAttr getFillTexture s of
@@ -181,6 +295,17 @@ renderFillTextureDefs i s =
     _           -> mempty
 
 -- Render the gradient using the id set up in renderFillTextureDefs.
+renderFillTexture' :: SVGFloat n => Int -> Style v n -> [Attribute]
+renderFillTexture' ident s = case getNumAttr getFillTexture s of
+  Just (SC (SomeColor c)) -> renderAttr' fill_ fillColorRgb <>
+                             renderAttr' fillOpacity_ fillColorOpacity
+    where
+      fillColorRgb     = Just $ colorToRgbText c
+      fillColorOpacity = Just $ colorToOpacity c
+  Just (LG _) -> [fill_ ("url(#gradient" <> toText ident <> ")"), fillOpacity_ "1"]
+  Just (RG _) -> [fill_ ("url(#gradient" <> toText ident <> ")"), fillOpacity_ "1"]
+  Nothing     -> []
+
 renderFillTexture :: SVGFloat n => Int -> Style v n -> S.Attribute
 renderFillTexture id_ s = case getNumAttr getFillTexture s of
   Just (SC (SomeColor c)) -> renderAttr A.fill fillColorRgb `mappend`
@@ -194,12 +319,30 @@ renderFillTexture id_ s = case getNumAttr getFillTexture s of
                 `mappend` A.fillOpacity "1"
   Nothing     -> mempty
 
+renderLineTextureDefs' :: SVGFloat n => Int -> Style v n -> Svg ()
+renderLineTextureDefs' i s =
+  case getNumAttr getLineTexture s of
+    Just (LG g) -> renderLinearGradient' g i
+    Just (RG g) -> renderRadialGradient' g i
+    _           -> mempty
+
 renderLineTextureDefs :: SVGFloat n => Int -> Style v n -> S.Svg
 renderLineTextureDefs i s =
   case getNumAttr getLineTexture s of
     Just (LG g) -> renderLinearGradient g i
     Just (RG g) -> renderRadialGradient g i
     _           -> mempty
+
+renderLineTexture' :: SVGFloat n => Int -> Style v n -> [Attribute]
+renderLineTexture' ident s = case getNumAttr getLineTexture s of
+  Just (SC (SomeColor c)) -> renderAttr' stroke_ lineColorRgb <>
+                             renderAttr' strokeOpacity_ lineColorOpacity
+    where
+      lineColorRgb     = Just $ colorToRgbText c
+      lineColorOpacity = Just $ colorToOpacity c
+  Just (LG _) -> [stroke_ ("url(#gradient" <> toText ident <> ")"), strokeOpacity_ "1"]
+  Just (RG _) -> [stroke_ ("url(#gradient" <> toText ident <> ")"), strokeOpacity_ "1"]
+  Nothing     -> []
 
 renderLineTexture :: SVGFloat n => Int -> Style v n -> S.Attribute
 renderLineTexture id_ s = case getNumAttr getLineTexture s of
@@ -214,8 +357,19 @@ renderLineTexture id_ s = case getNumAttr getLineTexture s of
                 `mappend` A.strokeOpacity "1"
   Nothing     -> mempty
 
+dataUri' :: String -> BS8.ByteString -> T.Text
+dataUri' mime dat = T.pack $ "data:"++mime++";base64," ++ BS8.unpack (BS64.encode dat)
+
 dataUri :: String -> BS8.ByteString -> String
 dataUri mime dat = "data:"++mime++";base64," ++ BS8.unpack (BS64.encode dat)
+
+renderDImageEmb' :: SVGFloat n => DImage n Embedded -> Svg ()
+renderDImageEmb' di@(DImage (ImageRaster dImg) _ _ _) =
+  renderDImage' di $ dataUri' "image/png" img
+  where
+    img = case encodeDynamicPng dImg of
+            Left str   -> error str
+            Right img' -> img'
 
 renderDImageEmb :: SVGFloat n => DImage n Embedded -> S.Svg
 renderDImageEmb di@(DImage (ImageRaster dImg) _ _ _) =
@@ -224,6 +378,20 @@ renderDImageEmb di@(DImage (ImageRaster dImg) _ _ _) =
     img = case encodeDynamicPng dImg of
             Left str   -> error str
             Right img' -> img'
+
+renderDImage' :: SVGFloat n => DImage n any -> T.Text -> Svg ()
+renderDImage' (DImage _ w h tr) uridata =
+  image_
+    [ transform_ transformMatrix
+    , width_ (toText w)
+    , height_ (toText h)
+    , xlinkHref_ uridata ]
+  where
+    [[a,b],[c,d],[e,f]] = matrixHomRep (tr `mappend` reflectionY
+                                           `mappend` tX `mappend` tY)
+    transformMatrix = matrix a b c d e f
+    tX = translationX $ fromIntegral (-w)/2
+    tY = translationY $ fromIntegral (-h)/2
 
 renderDImage :: SVGFloat n => DImage n any -> String -> S.Svg
 renderDImage (DImage _ w h tr) uridata =
@@ -238,6 +406,35 @@ renderDImage (DImage _ w h tr) uridata =
     transformMatrix = S.matrix a b c d e f
     tX = translationX $ fromIntegral (-w)/2
     tY = translationY $ fromIntegral (-h)/2
+
+-- XXX Why can't ghc infer this type? and why does it even work.
+-- In fact both `Svg ()`s can be replaced with an arbitrary type variable say `s`
+-- and it still works.
+-- https://github.com/chrisdone/lucid/blob/master/src/Lucid/Base.hs#L181
+renderText' :: (SVGFloat n, Term [Attribute] (T.Text -> Svg ())) => Text n -> Svg ()
+renderText' (Text tt tAlign str) =
+  text_
+    [ transform_ transformMatrix
+    , dominantBaseline_ vAlign
+    , textAnchor_ hAlign
+    , stroke_ "none" ]
+    (T.pack str)
+ where
+  vAlign = case tAlign of
+             BaselineText -> "alphabetic"
+             BoxAlignedText _ h -> case h of -- A mere approximation
+               h' | h' <= 0.25 -> "text-after-edge"
+               h' | h' >= 0.75 -> "text-before-edge"
+               _ -> "middle"
+  hAlign = case tAlign of
+             BaselineText -> "start"
+             BoxAlignedText w _ -> case w of -- A mere approximation
+               w' | w' <= 0.25 -> "start"
+               w' | w' >= 0.75 -> "end"
+               _ -> "middle"
+  t                   = tt `mappend` reflectionY
+  [[a,b],[c,d],[e,f]] = matrixHomRep t
+  transformMatrix     = matrix a b c d e f
 
 renderText :: SVGFloat n => Text n -> S.Svg
 renderText (Text tt tAlign str) =
@@ -264,6 +461,23 @@ renderText (Text tt tAlign str) =
   [[a,b],[c,d],[e,f]] = matrixHomRep t
   transformMatrix     = S.matrix a b c d e f
 
+renderStyles' :: SVGFloat n => Int -> Int -> Style v n -> [Attribute]
+renderStyles' fillId lineId s = concatMap ($ s) $
+  [ renderLineTexture' lineId
+  , renderFillTexture' fillId
+  , renderLineWidth'
+  , renderLineCap'
+  , renderLineJoin'
+  , renderFillRule'
+  , renderDashing'
+  , renderOpacity'
+  , renderFontSize'
+  , renderFontSlant'
+  , renderFontWeight'
+  , renderFontFamily'
+  , renderMiterLimit'
+  ]
+
 renderStyles :: SVGFloat n => Int -> Int -> Style v n -> S.Attribute
 renderStyles fillId lineId s = mconcat . map ($ s) $
   [ renderLineTexture lineId
@@ -281,13 +495,28 @@ renderStyles fillId lineId s = mconcat . map ($ s) $
   , renderMiterLimit
   ]
 
+renderMiterLimit' :: SVGFloat n => Style v n -> [Attribute]
+renderMiterLimit' s = renderAttr' strokeMiterlimit_ miterLimit
+ where miterLimit = getLineMiterLimit <$> getAttr s
+
 renderMiterLimit :: SVGFloat n => Style v n -> S.Attribute
 renderMiterLimit s = renderAttr A.strokeMiterlimit miterLimit
  where miterLimit = getLineMiterLimit <$> getAttr s
 
+renderOpacity' :: SVGFloat n => Style v n -> [Attribute]
+renderOpacity' s = renderAttr' opacity_ o
+ where o = getOpacity <$> getAttr s
+
 renderOpacity :: SVGFloat n => Style v n -> S.Attribute
 renderOpacity s = renderAttr A.opacity opacity_
  where opacity_ = getOpacity <$> getAttr s
+
+renderFillRule' :: SVGFloat n => Style v n -> [Attribute]
+renderFillRule' s = renderAttr' fillRule_ fr
+  where fr = (fillRuleToText . getFillRule) <$> getAttr s
+        fillRuleToText :: FillRule -> T.Text
+        fillRuleToText Winding = "nonzero"
+        fillRuleToText EvenOdd = "evenodd"
 
 renderFillRule :: SVGFloat n => Style v n -> S.Attribute
 renderFillRule s = renderAttr A.fillRule fillRule_
@@ -296,10 +525,22 @@ renderFillRule s = renderAttr A.fillRule fillRule_
         fillRuleToStr Winding = "nonzero"
         fillRuleToStr EvenOdd = "evenodd"
 
+renderLineWidth' :: SVGFloat n => Style v n -> [Attribute]
+renderLineWidth' s = renderAttr' strokeWidth_ lineWidth'
+  where lineWidth' = getNumAttr getLineWidth s
+
 renderLineWidth :: SVGFloat n => Style v n -> S.Attribute
 renderLineWidth s = renderAttr A.strokeWidth lineWidth'
   where lineWidth' = getNumAttr getLineWidth s
 
+
+renderLineCap' :: SVGFloat n => Style v n -> [Attribute]
+renderLineCap' s = renderAttr' strokeLinecap_ lc
+  where lc = (lineCapToText . getLineCap) <$> getAttr s
+        lineCapToText :: LineCap -> T.Text
+        lineCapToText LineCapButt   = "butt"
+        lineCapToText LineCapRound  = "round"
+        lineCapToText LineCapSquare = "square"
 
 renderLineCap :: SVGFloat n => Style v n -> S.Attribute
 renderLineCap s = renderAttr A.strokeLinecap lineCap_
@@ -309,6 +550,14 @@ renderLineCap s = renderAttr A.strokeLinecap lineCap_
         lineCapToStr LineCapRound  = "round"
         lineCapToStr LineCapSquare = "square"
 
+renderLineJoin' :: SVGFloat n => Style v n -> [Attribute]
+renderLineJoin' s = renderAttr' strokeLinejoin_ lj
+  where lj = (lineJoinToText . getLineJoin) <$> getAttr s
+        lineJoinToText :: LineJoin -> T.Text
+        lineJoinToText LineJoinMiter = "miter"
+        lineJoinToText LineJoinRound = "round"
+        lineJoinToText LineJoinBevel = "bevel"
+
 renderLineJoin :: SVGFloat n => Style v n -> S.Attribute
 renderLineJoin s = renderAttr A.strokeLinejoin lineJoin_
   where lineJoin_ = (lineJoinToStr . getLineJoin) <$> getAttr s
@@ -316,6 +565,17 @@ renderLineJoin s = renderAttr A.strokeLinejoin lineJoin_
         lineJoinToStr LineJoinMiter = "miter"
         lineJoinToStr LineJoinRound = "round"
         lineJoinToStr LineJoinBevel = "bevel"
+
+renderDashing' :: SVGFloat n => Style v n -> [Attribute]
+renderDashing' s = renderAttr' strokeDasharray_ arr <>
+                   renderAttr' strokeDashoffset_ dOffset
+ where
+  getDasharray  (Dashing a _) = a
+  getDashoffset (Dashing _ o) = o
+  dashArrayToStr              = intercalate "," . map show
+  dashing_                    = getNumAttr getDashing s
+  arr                         = (dashArrayToStr . getDasharray) <$> dashing_
+  dOffset                     = getDashoffset <$> dashing_
 
 renderDashing :: SVGFloat n => Style v n -> S.Attribute
 renderDashing s = renderAttr A.strokeDasharray arr `mappend`
@@ -328,10 +588,24 @@ renderDashing s = renderAttr A.strokeDasharray arr `mappend`
   arr                         = (dashArrayToStr . getDasharray) <$> dashing_
   dOffset                     = getDashoffset <$> dashing_
 
+renderFontSize' :: SVGFloat n => Style v n -> [Attribute]
+renderFontSize' s = renderAttr' fontSize_ fs
+ where
+  fs = getNumAttr ((++ "px") . show . getFontSize) s
+
 renderFontSize :: SVGFloat n => Style v n -> S.Attribute
 renderFontSize s = renderAttr A.fontSize fontSize_
  where
   fontSize_ = getNumAttr ((++ "px") . show . getFontSize) s
+
+renderFontSlant' :: SVGFloat n => Style v n -> [Attribute]
+renderFontSlant' s = renderAttr' fontStyle_ fs
+ where
+  fs = (fontSlantAttr . getFontSlant) <$> getAttr s
+  fontSlantAttr :: FontSlant -> T.Text
+  fontSlantAttr FontSlantItalic  = "italic"
+  fontSlantAttr FontSlantOblique = "oblique"
+  fontSlantAttr FontSlantNormal  = "normal"
 
 renderFontSlant :: SVGFloat n => Style v n -> S.Attribute
 renderFontSlant s = renderAttr A.fontStyle fontSlant_
@@ -342,6 +616,14 @@ renderFontSlant s = renderAttr A.fontStyle fontSlant_
   fontSlantAttr FontSlantOblique = "oblique"
   fontSlantAttr FontSlantNormal  = "normal"
 
+renderFontWeight' :: SVGFloat n => Style v n -> [Attribute]
+renderFontWeight' s = renderAttr' fontWeight_ fw
+ where
+  fw = (fontWeightAttr . getFontWeight) <$> getAttr s
+  fontWeightAttr :: FontWeight -> T.Text
+  fontWeightAttr FontWeightNormal = "normal"
+  fontWeightAttr FontWeightBold   = "bold"
+
 renderFontWeight :: SVGFloat n => Style v n -> S.Attribute
 renderFontWeight s = renderAttr A.fontWeight fontWeight_
  where
@@ -350,18 +632,41 @@ renderFontWeight s = renderAttr A.fontWeight fontWeight_
   fontWeightAttr FontWeightNormal = "normal"
   fontWeightAttr FontWeightBold   = "bold"
 
+renderFontFamily' :: SVGFloat n => Style v n -> [Attribute]
+renderFontFamily' s = renderAttr' fontFamily_ ff
+ where
+  ff = getFont <$> getAttr s
+
 renderFontFamily :: SVGFloat n => Style v n -> S.Attribute
 renderFontFamily s = renderAttr A.fontFamily fontFamily_
  where
   fontFamily_ = getFont <$> getAttr s
 
 -- | Render a style attribute if available, empty otherwise.
+renderAttr' :: Show s => (T.Text -> Attribute)
+           -> Maybe s
+           -> [Attribute]
+renderAttr' attr valM = case valM of
+  Just val -> [attr (toText val)]
+  Nothing  -> []
+  
 renderAttr :: S.ToValue s => (S.AttributeValue -> S.Attribute)
            -> Maybe s
            -> S.Attribute
 renderAttr attr valM = case valM of
   Just val -> attr (S.toValue val)
   Nothing  -> mempty
+
+colorToRgbText :: forall c . Color c => c -> T.Text
+colorToRgbText c = T.concat
+  [ "rgb("
+  , int r, ","
+  , int g, ","
+  , int b
+  , ")"
+  ]
+ where int d = toText (round (d * 255) :: Int)
+       (r,g,b,_) = colorToSRGBA c
 
 colorToRgbString :: forall c . Color c => c -> String
 colorToRgbString c = concat

--- a/src/Graphics/Rendering/SVG.hs
+++ b/src/Graphics/Rendering/SVG.hs
@@ -96,19 +96,19 @@ renderPath :: SVGFloat n => Path V2 n -> SvgM
 renderPath trs = if makePath == T.empty then mempty else path_ [d_ makePath]
 -- renderPath trs  = path_  [d_ (if makePath == T.empty then toText "" else makePath)]
   where
-    makePath = T.concat $ map renderTrail (op Path trs)
+    makePath = foldMap renderTrail (op Path trs)
 
 renderTrail :: SVGFloat n => Located (Trail V2 n) -> AttributeValue
 renderTrail (viewLoc -> (P (V2 x y), t)) = mA x y <> withTrail renderLine renderLoop t
   where
-    renderLine = T.concat . map renderSeg . lineSegments
+    renderLine = foldMap renderSeg . lineSegments
     renderLoop lp =
       case loopSegments lp of
         -- let z handle the last segment if it is linear
-        (segs, Linear _) -> T.concat $ map renderSeg segs
+        (segs, Linear _) -> foldMap renderSeg segs
 
         -- otherwise we have to emit it explicitly
-        _ -> T.concat $ map renderSeg (lineSegments . cutLoop $ lp)
+        _ -> foldMap renderSeg (lineSegments . cutLoop $ lp)
       <> z
 
 renderSeg :: SVGFloat n => Segment Closed V2 n -> AttributeValue

--- a/src/Graphics/Rendering/SVG.hs
+++ b/src/Graphics/Rendering/SVG.hs
@@ -234,18 +234,14 @@ renderDImage (DImage _ w h tr) uridata =
     tX = translationX $ fromIntegral (-w)/2
     tY = translationY $ fromIntegral (-h)/2
 
--- XXX Why cant ghc infer this type? and why does it even work.
--- In fact both `Svg ()`s can be replaced with an arbitrary type variable say `s`
--- and it still works.
--- https://github.com/chrisdone/lucid/blob/master/src/Lucid/Base.hs#L181
-renderText :: (SVGFloat n, Term [Attribute] (T.Text -> Svg ())) => Text n -> Svg ()
+renderText :: SVGFloat n => Text n -> Svg ()
 renderText (Text tt tAlign str) =
   text_
     [ transform_ transformMatrix
     , dominantBaseline_ vAlign
     , textAnchor_ hAlign
     , stroke_ "none" ]
-    (T.pack str)
+    (toHtml str)
  where
   vAlign = case tAlign of
              BaselineText -> "alphabetic"
@@ -327,9 +323,9 @@ renderDashing s = renderTextAttr strokeDasharray_ arr <>
   dOffset                     = getDashoffset <$> dashing_
 
 renderFontSize :: SVGFloat n => Style v n -> [Attribute]
-renderFontSize s = renderAttr fontSize_ fs
+renderFontSize s = renderTextAttr fontSize_ fs
  where
-  fs = getNumAttr ((++ "px") . show . getFontSize) s
+  fs = T.pack <$> getNumAttr ((++ "px") . show . getFontSize) s
 
 renderFontSlant :: SVGFloat n => Style v n -> [Attribute]
 renderFontSlant s = renderTextAttr fontStyle_ fs

--- a/src/Graphics/Rendering/SVG.hs
+++ b/src/Graphics/Rendering/SVG.hs
@@ -36,7 +36,6 @@ module Graphics.Rendering.SVG
 
 -- from base
 import           Data.List                   (intercalate)
-import qualified Data.Foldable as F
 import           Data.Foldable (foldMap)
 
 -- from lens
@@ -55,31 +54,25 @@ import           Data.Monoid
 import           Lucid.Svg                   hiding (renderText)
 
 -- from blaze-svg
-import           Text.Blaze.Svg11            (cr, hr, lr, m, mkPath, vr, (!))
-import qualified Text.Blaze.Svg11            as S
-import qualified Text.Blaze.Svg11.Attributes as A
 import qualified Data.ByteString.Base64.Lazy as BS64
 import qualified Data.ByteString.Lazy.Char8  as BS8
 
 import           Codec.Picture
 
 -- | Constaint on number type that diagrams-svg can use to render an SVG. This
---   includes the common number types: 'Double', 'Float'
-type SVGFloat n = (Show n, TypeableFloat n, S.ToValue n)
+--   includes the common number types: Double, Float
+type SVGFloat n = (Show n, TypeableFloat n)
 -- Could we change Text.Blaze.SVG to use
 --   showFFloat :: RealFloat a => Maybe Int -> a -> ShowS
 -- or something similar for all numbers so we need TypeableFloat constraint.
-
-toText :: Show a => a -> T.Text
-toText = T.pack . show
 
 getNumAttr :: AttributeClass (a n) => (a n -> t) -> Style v n -> Maybe t
 getNumAttr f = (f <$>) . getAttr
 
 -- | @svgHeader w h defs s@: @w@ width, @h@ height,
 --   @defs@ global definitions for defs sections, @s@ actual SVG content.
-svgHeader' :: SVGFloat n => n -> n -> [Attribute] -> Svg () -> Svg ()
-svgHeader' w h defines s =  doctype_ <> with (svg11_ (g_ (defs_ defines s)))
+svgHeader :: SVGFloat n => n -> n -> [Attribute] -> Svg () -> Svg ()
+svgHeader w h defines s =  doctype_ <> with (svg11_ (g_ (defs_ defines s)))
   [ version_ "1.1"
   , width_    (toText w)
   , height_   (toText h)
@@ -88,107 +81,52 @@ svgHeader' w h defines s =  doctype_ <> with (svg11_ (g_ (defs_ defines s)))
   , stroke_ "rgb(0,0,0)"
   , strokeOpacity_ "1" ]
 
-svgHeader :: SVGFloat n => n -> n -> Maybe S.Svg -> S.Svg -> S.Svg
-svgHeader w h_ defines s =  S.docTypeSvg
-  ! A.version "1.1"
-  ! A.width    (S.toValue w)
-  ! A.height   (S.toValue h_)
-  ! A.fontSize "1"
-  ! A.viewbox (S.toValue . unwords $ map show ([0, 0, round w, round h_] :: [Int]))
-  ! A.stroke "rgb(0,0,0)"
-  ! A.strokeOpacity "1"
-  $ F.mapM_ S.defs defines >> S.g s
-
-renderPath' :: SVGFloat n => Path V2 n -> Svg ()
-renderPath' trs  = path_  [d_ makePath]
+renderPath :: SVGFloat n => Path V2 n -> Svg ()
+renderPath trs  = path_  [d_ makePath]
   where
-    makePath = T.concat $ map renderTrail' (op Path trs)
+    makePath = T.concat $ map renderTrail (op Path trs)
 
-renderPath :: SVGFloat n => Path V2 n -> S.Svg
-renderPath trs  = S.path ! A.d makePath
+renderTrail :: SVGFloat n => Located (Trail V2 n) -> T.Text
+renderTrail (viewLoc -> (P (V2 x y), t)) = mR x y <> withTrail renderLine renderLoop t
   where
-    makePath = mkPath $ mapM_ renderTrail (op Path trs)
-
-renderTrail' :: SVGFloat n => Located (Trail V2 n) -> T.Text
-renderTrail' (viewLoc -> (P (V2 x y), t)) = mR x y <> withTrail renderLine renderLoop t
-  where
-    renderLine = T.concat . map renderSeg' . lineSegments
+    renderLine = T.concat . map renderSeg . lineSegments
     renderLoop lp =
       case loopSegments lp of
-        -- let 'z' handle the last segment if it is linear
-        (segs, Linear _) -> T.concat $ map renderSeg' segs
+        -- let z handle the last segment if it is linear
+        (segs, Linear _) -> T.concat $ map renderSeg segs
 
         -- otherwise we have to emit it explicitly
-        _ -> T.concat $ map renderSeg' (lineSegments . cutLoop $ lp)
+        _ -> T.concat $ map renderSeg (lineSegments . cutLoop $ lp)
       <> z
 
-renderTrail :: SVGFloat n => Located (Trail V2 n) -> S.Path
-renderTrail (viewLoc -> (P (V2 x y), t)) = m x y >> withTrail renderLine renderLoop t
-  where
-    renderLine = mapM_ renderSeg . lineSegments
-    renderLoop lp = do
-      case loopSegments lp of
-        -- let 'z' handle the last segment if it is linear
-        (segs, Linear _) -> mapM_ renderSeg segs
-
-        -- otherwise we have to emit it explicitly
-        _ -> mapM_ renderSeg (lineSegments . cutLoop $ lp)
-      S.z
-
-renderSeg' :: SVGFloat n => Segment Closed V2 n -> T.Text
-renderSeg' (Linear (OffsetClosed (V2 x 0))) = hR x
-renderSeg' (Linear (OffsetClosed (V2 0 y))) = vR y
-renderSeg' (Linear (OffsetClosed (V2 x y))) = lR x y
-renderSeg' (Cubic  (V2 x0 y0)
+renderSeg :: SVGFloat n => Segment Closed V2 n -> T.Text
+renderSeg (Linear (OffsetClosed (V2 x 0))) = hR x
+renderSeg (Linear (OffsetClosed (V2 0 y))) = vR y
+renderSeg (Linear (OffsetClosed (V2 x y))) = lR x y
+renderSeg (Cubic  (V2 x0 y0)
                   (V2 x1 y1)
                   (OffsetClosed (V2 x2 y2))) = cR x0 y0 x1 y1 x2 y2
 
-renderSeg :: SVGFloat n => Segment Closed V2 n -> S.Path
-renderSeg (Linear (OffsetClosed (V2 x 0))) = hr x
-renderSeg (Linear (OffsetClosed (V2 0 y))) = vr y
-renderSeg (Linear (OffsetClosed (V2 x y))) = lr x y
-renderSeg (Cubic  (V2 x0 y0)
-                  (V2 x1 y1)
-                  (OffsetClosed (V2 x2 y2))) = cr x0 y0 x1 y1 x2 y2
-
-renderClip' :: SVGFloat n => Path V2 n -> Int -> Svg () -> Svg ()
-renderClip' p ident svg =
+renderClip :: SVGFloat n => Path V2 n -> Int -> Svg () -> Svg ()
+renderClip p ident svg =
   g_  [clipPath_ $ ("url(#" <> clipPathId ident <> ")")] $ do
-    clippath_ [id_ (clipPathId ident)] (renderPath' p)
+    clipPath_ [id_ (clipPathId ident)] (renderPath p)
     svg
   where clipPathId i = "myClip" <> (toText i)
 
-renderClip :: SVGFloat n => Path V2 n -> Int -> S.Svg -> S.Svg
-renderClip p id_ svg =
-  S.g ! A.clipPath (S.toValue $ "url(#" ++ clipPathId id_ ++ ")") $ do
-    S.clippath ! A.id_ (S.toValue $ clipPathId id_) $ renderPath p
-    svg
-  where clipPathId i = "myClip" ++ show i
-
-renderStop' :: SVGFloat n => GradientStop n -> Svg ()
-renderStop' (GradientStop c v)
+renderStop :: SVGFloat n => GradientStop n -> Svg ()
+renderStop (GradientStop c v)
   = stop_ [ stopColor_ (colorToRgbText c)
           , offset_ (toText v)
           , stopOpacity_ (toText $ colorToOpacity c) ]
-
-renderStop :: SVGFloat n => GradientStop n -> S.Svg
-renderStop (GradientStop c v)
-  = S.stop ! A.stopColor (S.toValue (colorToRgbString c))
-           ! A.offset (S.toValue (show v))
-           ! A.stopOpacity (S.toValue (colorToOpacity c))
 
 spreadMethodText :: SpreadMethod -> T.Text
 spreadMethodText GradPad      = "pad"
 spreadMethodText GradReflect  = "reflect"
 spreadMethodText GradRepeat   = "repeat"
 
-spreadMethodStr :: SpreadMethod -> String
-spreadMethodStr GradPad      = "pad"
-spreadMethodStr GradReflect  = "reflect"
-spreadMethodStr GradRepeat   = "repeat"
-
-renderLinearGradient' :: SVGFloat n => LGradient n -> Int -> Svg ()
-renderLinearGradient' g i = linearGradient_
+renderLinearGradient :: SVGFloat n => LGradient n -> Int -> Svg ()
+renderLinearGradient g i = linearGradient_
     [ id_ (T.pack $ "gradient" ++ show i)
     , x1_  (toText x1)
     , y1_  (toText y1)
@@ -197,76 +135,30 @@ renderLinearGradient' g i = linearGradient_
     , gradientTransform_ mx
     , gradientUnits_ "userSpaceOnUse"
     , spreadMethod_ (spreadMethodText (g^.lGradSpreadMethod)) ]
-    ( foldMap renderStop' (g^.lGradStops) )
+    ( foldMap renderStop (g^.lGradStops) )
   where
     mx = matrix a1 a2 b1 b2 c1 c2
     [[a1, a2], [b1, b2], [c1, c2]] = matrixHomRep (g^.lGradTrans)
     P (V2 x1 y1) = g ^. lGradStart
     P (V2 x2 y2) = g ^. lGradEnd
 
-renderLinearGradient :: SVGFloat n => LGradient n -> Int -> S.Svg
-renderLinearGradient g i = S.lineargradient
-    ! A.id_ (S.toValue ("gradient" ++ show i))
-    ! A.x1  (S.toValue x1)
-    ! A.y1  (S.toValue y1)
-    ! A.x2  (S.toValue x2)
-    ! A.y2  (S.toValue y2)
-    ! A.gradienttransform (S.toValue matrix)
-    ! A.gradientunits "userSpaceOnUse"
-    ! A.spreadmethod (S.toValue (spreadMethodStr (g^.lGradSpreadMethod)))
-    $ foldMap renderStop (g^.lGradStops)
-  where
-    matrix = S.matrix a1 a2 b1 b2 c1 c2
-    [[a1, a2], [b1, b2], [c1, c2]] = matrixHomRep (g^.lGradTrans)
-    P (V2 x1 y1) = g ^. lGradStart
-    P (V2 x2 y2) = g ^. lGradEnd
-
-renderRadialGradient' :: SVGFloat n => RGradient n -> Int -> Svg ()
-renderRadialGradient' g i = radialGradient_
+renderRadialGradient :: SVGFloat n => RGradient n -> Int -> Svg ()
+renderRadialGradient g i = radialGradient_
     [ id_ (T.pack $ "gradient" ++ show i)
     , r_ (toText (g^.rGradRadius1))
-    , cx_ (toText cx')
-    , cy_ (toText cy')
-    , fx_ (toText fx')
-    , fy_ (toText fy')
+    , cx_ (toText cx)
+    , cy_ (toText cy)
+    , fx_ (toText fx)
+    , fy_ (toText fy)
     , gradientTransform_ mx
     , gradientUnits_ "userSpaceOnUse"
     , spreadMethod_ (spreadMethodText (g^.rGradSpreadMethod)) ]
-    ( foldMap renderStop' ss )
+    ( foldMap renderStop ss )
   where
     mx = matrix a1 a2 b1 b2 c1 c2
     [[a1, a2], [b1, b2], [c1, c2]] = matrixHomRep (g^.rGradTrans)
-    P (V2 cx' cy') = g ^. rGradCenter1
-    P (V2 fx' fy') = g ^. rGradCenter0 -- SVG's focal point is our inner center.
-
-    -- Adjust the stops so that the gradient begins at the perimeter of
-    -- the inner circle (center0, radius0) and ends at the outer circle.
-    r0 = g^.rGradRadius0
-    r1 = g^.rGradRadius1
-    stopFracs = r0 / r1 : map (\s -> (r0 + (s^.stopFraction) * (r1 - r0)) / r1)
-                (g^.rGradStops)
-    gradStops = case g^.rGradStops of
-      []       -> []
-      xs@(x:_) -> x : xs
-    ss = zipWith (\gs sf -> gs & stopFraction .~ sf ) gradStops stopFracs
-
-renderRadialGradient :: SVGFloat n => RGradient n -> Int -> S.Svg
-renderRadialGradient g i = S.radialgradient
-    ! A.id_ (S.toValue ("gradient" ++ show i))
-    ! A.r (S.toValue (g^.rGradRadius1))
-    ! A.cx (S.toValue cx')
-    ! A.cy (S.toValue cy')
-    ! A.fx (S.toValue fx')
-    ! A.fy (S.toValue fy')
-    ! A.gradienttransform (S.toValue matrix)
-    ! A.gradientunits "userSpaceOnUse"
-    ! A.spreadmethod (S.toValue (spreadMethodStr (g^.rGradSpreadMethod)))
-    $ foldMap renderStop ss
-  where
-    matrix = S.matrix a1 a2 b1 b2 c1 c2
-    [[a1, a2], [b1, b2], [c1, c2]] = matrixHomRep (g^.rGradTrans)
-    P (V2 cx' cy') = g ^. rGradCenter1
-    P (V2 fx' fy') = g ^. rGradCenter0 -- SVG's focal point is our inner center.
+    P (V2 cx cy) = g ^. rGradCenter1
+    P (V2 fx fy) = g ^. rGradCenter0 -- SVGs focal point is our inner center.
 
     -- Adjust the stops so that the gradient begins at the perimeter of
     -- the inner circle (center0, radius0) and ends at the outer circle.
@@ -280,14 +172,7 @@ renderRadialGradient g i = S.radialgradient
     ss = zipWith (\gs sf -> gs & stopFraction .~ sf ) gradStops stopFracs
 
 -- Create a gradient element so that it can be used as an attribute value for fill.
-renderFillTextureDefs' :: SVGFloat n => Int -> Style v n -> Svg ()
-renderFillTextureDefs' i s =
-  case getNumAttr getFillTexture s of
-    Just (LG g) -> renderLinearGradient' g i
-    Just (RG g) -> renderRadialGradient' g i
-    _           -> mempty
-
-renderFillTextureDefs :: SVGFloat n => Int -> Style v n -> S.Svg
+renderFillTextureDefs :: SVGFloat n => Int -> Style v n -> Svg ()
 renderFillTextureDefs i s =
   case getNumAttr getFillTexture s of
     Just (LG g) -> renderLinearGradient g i
@@ -295,10 +180,10 @@ renderFillTextureDefs i s =
     _           -> mempty
 
 -- Render the gradient using the id set up in renderFillTextureDefs.
-renderFillTexture' :: SVGFloat n => Int -> Style v n -> [Attribute]
-renderFillTexture' ident s = case getNumAttr getFillTexture s of
-  Just (SC (SomeColor c)) -> renderAttr' fill_ fillColorRgb <>
-                             renderAttr' fillOpacity_ fillColorOpacity
+renderFillTexture :: SVGFloat n => Int -> Style v n -> [Attribute]
+renderFillTexture ident s = case getNumAttr getFillTexture s of
+  Just (SC (SomeColor c)) -> renderAttr fill_ fillColorRgb <>
+                             renderAttr fillOpacity_ fillColorOpacity
     where
       fillColorRgb     = Just $ colorToRgbText c
       fillColorOpacity = Just $ colorToOpacity c
@@ -306,37 +191,17 @@ renderFillTexture' ident s = case getNumAttr getFillTexture s of
   Just (RG _) -> [fill_ ("url(#gradient" <> toText ident <> ")"), fillOpacity_ "1"]
   Nothing     -> []
 
-renderFillTexture :: SVGFloat n => Int -> Style v n -> S.Attribute
-renderFillTexture id_ s = case getNumAttr getFillTexture s of
-  Just (SC (SomeColor c)) -> renderAttr A.fill fillColorRgb `mappend`
-                             renderAttr A.fillOpacity fillColorOpacity
-    where
-      fillColorRgb     = Just $ colorToRgbString c
-      fillColorOpacity = Just $ colorToOpacity c
-  Just (LG _) -> A.fill (S.toValue ("url(#gradient" ++ show id_ ++ ")"))
-                `mappend` A.fillOpacity "1"
-  Just (RG _) -> A.fill (S.toValue ("url(#gradient" ++ show id_ ++ ")"))
-                `mappend` A.fillOpacity "1"
-  Nothing     -> mempty
-
-renderLineTextureDefs' :: SVGFloat n => Int -> Style v n -> Svg ()
-renderLineTextureDefs' i s =
-  case getNumAttr getLineTexture s of
-    Just (LG g) -> renderLinearGradient' g i
-    Just (RG g) -> renderRadialGradient' g i
-    _           -> mempty
-
-renderLineTextureDefs :: SVGFloat n => Int -> Style v n -> S.Svg
+renderLineTextureDefs :: SVGFloat n => Int -> Style v n -> Svg ()
 renderLineTextureDefs i s =
   case getNumAttr getLineTexture s of
     Just (LG g) -> renderLinearGradient g i
     Just (RG g) -> renderRadialGradient g i
     _           -> mempty
 
-renderLineTexture' :: SVGFloat n => Int -> Style v n -> [Attribute]
-renderLineTexture' ident s = case getNumAttr getLineTexture s of
-  Just (SC (SomeColor c)) -> renderAttr' stroke_ lineColorRgb <>
-                             renderAttr' strokeOpacity_ lineColorOpacity
+renderLineTexture :: SVGFloat n => Int -> Style v n -> [Attribute]
+renderLineTexture ident s = case getNumAttr getLineTexture s of
+  Just (SC (SomeColor c)) -> renderAttr stroke_ lineColorRgb <>
+                             renderAttr strokeOpacity_ lineColorOpacity
     where
       lineColorRgb     = Just $ colorToRgbText c
       lineColorOpacity = Just $ colorToOpacity c
@@ -344,34 +209,10 @@ renderLineTexture' ident s = case getNumAttr getLineTexture s of
   Just (RG _) -> [stroke_ ("url(#gradient" <> toText ident <> ")"), strokeOpacity_ "1"]
   Nothing     -> []
 
-renderLineTexture :: SVGFloat n => Int -> Style v n -> S.Attribute
-renderLineTexture id_ s = case getNumAttr getLineTexture s of
-  Just (SC (SomeColor c)) -> renderAttr A.stroke lineColorRgb `mappend`
-                             renderAttr A.strokeOpacity lineColorOpacity
-    where
-      lineColorRgb     = Just $ colorToRgbString c
-      lineColorOpacity = Just $ colorToOpacity c
-  Just (LG _) -> A.stroke (S.toValue ("url(#gradient" ++ show id_ ++ ")"))
-                `mappend` A.strokeOpacity "1"
-  Just (RG _) -> A.stroke (S.toValue ("url(#gradient" ++ show id_ ++ ")"))
-                `mappend` A.strokeOpacity "1"
-  Nothing     -> mempty
+dataUri :: String -> BS8.ByteString -> T.Text
+dataUri mime dat = T.pack $ "data:"++mime++";base64," ++ BS8.unpack (BS64.encode dat)
 
-dataUri' :: String -> BS8.ByteString -> T.Text
-dataUri' mime dat = T.pack $ "data:"++mime++";base64," ++ BS8.unpack (BS64.encode dat)
-
-dataUri :: String -> BS8.ByteString -> String
-dataUri mime dat = "data:"++mime++";base64," ++ BS8.unpack (BS64.encode dat)
-
-renderDImageEmb' :: SVGFloat n => DImage n Embedded -> Svg ()
-renderDImageEmb' di@(DImage (ImageRaster dImg) _ _ _) =
-  renderDImage' di $ dataUri' "image/png" img
-  where
-    img = case encodeDynamicPng dImg of
-            Left str   -> error str
-            Right img' -> img'
-
-renderDImageEmb :: SVGFloat n => DImage n Embedded -> S.Svg
+renderDImageEmb :: SVGFloat n => DImage n Embedded -> Svg ()
 renderDImageEmb di@(DImage (ImageRaster dImg) _ _ _) =
   renderDImage di $ dataUri "image/png" img
   where
@@ -379,8 +220,8 @@ renderDImageEmb di@(DImage (ImageRaster dImg) _ _ _) =
             Left str   -> error str
             Right img' -> img'
 
-renderDImage' :: SVGFloat n => DImage n any -> T.Text -> Svg ()
-renderDImage' (DImage _ w h tr) uridata =
+renderDImage :: SVGFloat n => DImage n any -> T.Text -> Svg ()
+renderDImage (DImage _ w h tr) uridata =
   image_
     [ transform_ transformMatrix
     , width_ (toText w)
@@ -393,26 +234,12 @@ renderDImage' (DImage _ w h tr) uridata =
     tX = translationX $ fromIntegral (-w)/2
     tY = translationY $ fromIntegral (-h)/2
 
-renderDImage :: SVGFloat n => DImage n any -> String -> S.Svg
-renderDImage (DImage _ w h tr) uridata =
-  S.image
-    ! A.transform transformMatrix
-    ! A.width (S.toValue w)
-    ! A.height (S.toValue h)
-    ! A.xlinkHref (S.preEscapedToValue uridata)
-  where
-    [[a,b],[c,d],[e,f]] = matrixHomRep (tr `mappend` reflectionY
-                                           `mappend` tX `mappend` tY)
-    transformMatrix = S.matrix a b c d e f
-    tX = translationX $ fromIntegral (-w)/2
-    tY = translationY $ fromIntegral (-h)/2
-
--- XXX Why can't ghc infer this type? and why does it even work.
+-- XXX Why cant ghc infer this type? and why does it even work.
 -- In fact both `Svg ()`s can be replaced with an arbitrary type variable say `s`
 -- and it still works.
 -- https://github.com/chrisdone/lucid/blob/master/src/Lucid/Base.hs#L181
-renderText' :: (SVGFloat n, Term [Attribute] (T.Text -> Svg ())) => Text n -> Svg ()
-renderText' (Text tt tAlign str) =
+renderText :: (SVGFloat n, Term [Attribute] (T.Text -> Svg ())) => Text n -> Svg ()
+renderText (Text tt tAlign str) =
   text_
     [ transform_ transformMatrix
     , dominantBaseline_ vAlign
@@ -436,50 +263,8 @@ renderText' (Text tt tAlign str) =
   [[a,b],[c,d],[e,f]] = matrixHomRep t
   transformMatrix     = matrix a b c d e f
 
-renderText :: SVGFloat n => Text n -> S.Svg
-renderText (Text tt tAlign str) =
-  S.text_
-    ! A.transform transformMatrix
-    ! A.dominantBaseline vAlign
-    ! A.textAnchor hAlign
-    ! A.stroke "none" $
-      S.toMarkup str
- where
-  vAlign = case tAlign of
-             BaselineText -> "alphabetic"
-             BoxAlignedText _ h -> case h of -- A mere approximation
-               h' | h' <= 0.25 -> "text-after-edge"
-               h' | h' >= 0.75 -> "text-before-edge"
-               _ -> "middle"
-  hAlign = case tAlign of
-             BaselineText -> "start"
-             BoxAlignedText w _ -> case w of -- A mere approximation
-               w' | w' <= 0.25 -> "start"
-               w' | w' >= 0.75 -> "end"
-               _ -> "middle"
-  t                   = tt `mappend` reflectionY
-  [[a,b],[c,d],[e,f]] = matrixHomRep t
-  transformMatrix     = S.matrix a b c d e f
-
-renderStyles' :: SVGFloat n => Int -> Int -> Style v n -> [Attribute]
-renderStyles' fillId lineId s = concatMap ($ s) $
-  [ renderLineTexture' lineId
-  , renderFillTexture' fillId
-  , renderLineWidth'
-  , renderLineCap'
-  , renderLineJoin'
-  , renderFillRule'
-  , renderDashing'
-  , renderOpacity'
-  , renderFontSize'
-  , renderFontSlant'
-  , renderFontWeight'
-  , renderFontFamily'
-  , renderMiterLimit'
-  ]
-
-renderStyles :: SVGFloat n => Int -> Int -> Style v n -> S.Attribute
-renderStyles fillId lineId s = mconcat . map ($ s) $
+renderStyles :: SVGFloat n => Int -> Int -> Style v n -> [Attribute]
+renderStyles fillId lineId s = concatMap ($ s) $
   [ renderLineTexture lineId
   , renderFillTexture fillId
   , renderLineWidth
@@ -495,80 +280,44 @@ renderStyles fillId lineId s = mconcat . map ($ s) $
   , renderMiterLimit
   ]
 
-renderMiterLimit' :: SVGFloat n => Style v n -> [Attribute]
-renderMiterLimit' s = renderAttr' strokeMiterlimit_ miterLimit
+renderMiterLimit :: SVGFloat n => Style v n -> [Attribute]
+renderMiterLimit s = renderAttr strokeMiterlimit_ miterLimit
  where miterLimit = getLineMiterLimit <$> getAttr s
 
-renderMiterLimit :: SVGFloat n => Style v n -> S.Attribute
-renderMiterLimit s = renderAttr A.strokeMiterlimit miterLimit
- where miterLimit = getLineMiterLimit <$> getAttr s
-
-renderOpacity' :: SVGFloat n => Style v n -> [Attribute]
-renderOpacity' s = renderAttr' opacity_ o
+renderOpacity :: SVGFloat n => Style v n -> [Attribute]
+renderOpacity s = renderAttr opacity_ o
  where o = getOpacity <$> getAttr s
 
-renderOpacity :: SVGFloat n => Style v n -> S.Attribute
-renderOpacity s = renderAttr A.opacity opacity_
- where opacity_ = getOpacity <$> getAttr s
-
-renderFillRule' :: SVGFloat n => Style v n -> [Attribute]
-renderFillRule' s = renderAttr' fillRule_ fr
+renderFillRule :: SVGFloat n => Style v n -> [Attribute]
+renderFillRule s = renderAttr fillRule_ fr
   where fr = (fillRuleToText . getFillRule) <$> getAttr s
         fillRuleToText :: FillRule -> T.Text
         fillRuleToText Winding = "nonzero"
         fillRuleToText EvenOdd = "evenodd"
 
-renderFillRule :: SVGFloat n => Style v n -> S.Attribute
-renderFillRule s = renderAttr A.fillRule fillRule_
-  where fillRule_ = (fillRuleToStr . getFillRule) <$> getAttr s
-        fillRuleToStr :: FillRule -> String
-        fillRuleToStr Winding = "nonzero"
-        fillRuleToStr EvenOdd = "evenodd"
+renderLineWidth :: SVGFloat n => Style v n -> [Attribute]
+renderLineWidth s = renderAttr strokeWidth_ lWidth
+  where lWidth = getNumAttr getLineWidth s
 
-renderLineWidth' :: SVGFloat n => Style v n -> [Attribute]
-renderLineWidth' s = renderAttr' strokeWidth_ lineWidth'
-  where lineWidth' = getNumAttr getLineWidth s
-
-renderLineWidth :: SVGFloat n => Style v n -> S.Attribute
-renderLineWidth s = renderAttr A.strokeWidth lineWidth'
-  where lineWidth' = getNumAttr getLineWidth s
-
-
-renderLineCap' :: SVGFloat n => Style v n -> [Attribute]
-renderLineCap' s = renderAttr' strokeLinecap_ lc
-  where lc = (lineCapToText . getLineCap) <$> getAttr s
+renderLineCap :: SVGFloat n => Style v n -> [Attribute]
+renderLineCap s = renderAttr strokeLinecap_ lCap
+  where lCap = (lineCapToText . getLineCap) <$> getAttr s
         lineCapToText :: LineCap -> T.Text
         lineCapToText LineCapButt   = "butt"
         lineCapToText LineCapRound  = "round"
         lineCapToText LineCapSquare = "square"
 
-renderLineCap :: SVGFloat n => Style v n -> S.Attribute
-renderLineCap s = renderAttr A.strokeLinecap lineCap_
-  where lineCap_ = (lineCapToStr . getLineCap) <$> getAttr s
-        lineCapToStr :: LineCap -> String
-        lineCapToStr LineCapButt   = "butt"
-        lineCapToStr LineCapRound  = "round"
-        lineCapToStr LineCapSquare = "square"
-
-renderLineJoin' :: SVGFloat n => Style v n -> [Attribute]
-renderLineJoin' s = renderAttr' strokeLinejoin_ lj
+renderLineJoin :: SVGFloat n => Style v n -> [Attribute]
+renderLineJoin s = renderAttr strokeLinejoin_ lj
   where lj = (lineJoinToText . getLineJoin) <$> getAttr s
         lineJoinToText :: LineJoin -> T.Text
         lineJoinToText LineJoinMiter = "miter"
         lineJoinToText LineJoinRound = "round"
         lineJoinToText LineJoinBevel = "bevel"
 
-renderLineJoin :: SVGFloat n => Style v n -> S.Attribute
-renderLineJoin s = renderAttr A.strokeLinejoin lineJoin_
-  where lineJoin_ = (lineJoinToStr . getLineJoin) <$> getAttr s
-        lineJoinToStr :: LineJoin -> String
-        lineJoinToStr LineJoinMiter = "miter"
-        lineJoinToStr LineJoinRound = "round"
-        lineJoinToStr LineJoinBevel = "bevel"
-
-renderDashing' :: SVGFloat n => Style v n -> [Attribute]
-renderDashing' s = renderAttr' strokeDasharray_ arr <>
-                   renderAttr' strokeDashoffset_ dOffset
+renderDashing :: SVGFloat n => Style v n -> [Attribute]
+renderDashing s = renderAttr strokeDasharray_ arr <>
+                   renderAttr strokeDashoffset_ dOffset
  where
   getDasharray  (Dashing a _) = a
   getDashoffset (Dashing _ o) = o
@@ -577,29 +326,13 @@ renderDashing' s = renderAttr' strokeDasharray_ arr <>
   arr                         = (dashArrayToStr . getDasharray) <$> dashing_
   dOffset                     = getDashoffset <$> dashing_
 
-renderDashing :: SVGFloat n => Style v n -> S.Attribute
-renderDashing s = renderAttr A.strokeDasharray arr `mappend`
-                  renderAttr A.strokeDashoffset dOffset
- where
-  getDasharray  (Dashing a _) = a
-  getDashoffset (Dashing _ o) = o
-  dashArrayToStr              = intercalate "," . map show
-  dashing_                    = getNumAttr getDashing s
-  arr                         = (dashArrayToStr . getDasharray) <$> dashing_
-  dOffset                     = getDashoffset <$> dashing_
-
-renderFontSize' :: SVGFloat n => Style v n -> [Attribute]
-renderFontSize' s = renderAttr' fontSize_ fs
+renderFontSize :: SVGFloat n => Style v n -> [Attribute]
+renderFontSize s = renderAttr fontSize_ fs
  where
   fs = getNumAttr ((++ "px") . show . getFontSize) s
 
-renderFontSize :: SVGFloat n => Style v n -> S.Attribute
-renderFontSize s = renderAttr A.fontSize fontSize_
- where
-  fontSize_ = getNumAttr ((++ "px") . show . getFontSize) s
-
-renderFontSlant' :: SVGFloat n => Style v n -> [Attribute]
-renderFontSlant' s = renderAttr' fontStyle_ fs
+renderFontSlant :: SVGFloat n => Style v n -> [Attribute]
+renderFontSlant s = renderAttr fontStyle_ fs
  where
   fs = (fontSlantAttr . getFontSlant) <$> getAttr s
   fontSlantAttr :: FontSlant -> T.Text
@@ -607,55 +340,26 @@ renderFontSlant' s = renderAttr' fontStyle_ fs
   fontSlantAttr FontSlantOblique = "oblique"
   fontSlantAttr FontSlantNormal  = "normal"
 
-renderFontSlant :: SVGFloat n => Style v n -> S.Attribute
-renderFontSlant s = renderAttr A.fontStyle fontSlant_
- where
-  fontSlant_ = (fontSlantAttr . getFontSlant) <$> getAttr s
-  fontSlantAttr :: FontSlant -> String
-  fontSlantAttr FontSlantItalic  = "italic"
-  fontSlantAttr FontSlantOblique = "oblique"
-  fontSlantAttr FontSlantNormal  = "normal"
-
-renderFontWeight' :: SVGFloat n => Style v n -> [Attribute]
-renderFontWeight' s = renderAttr' fontWeight_ fw
+renderFontWeight :: SVGFloat n => Style v n -> [Attribute]
+renderFontWeight s = renderAttr fontWeight_ fw
  where
   fw = (fontWeightAttr . getFontWeight) <$> getAttr s
   fontWeightAttr :: FontWeight -> T.Text
   fontWeightAttr FontWeightNormal = "normal"
   fontWeightAttr FontWeightBold   = "bold"
 
-renderFontWeight :: SVGFloat n => Style v n -> S.Attribute
-renderFontWeight s = renderAttr A.fontWeight fontWeight_
- where
-  fontWeight_ = (fontWeightAttr . getFontWeight) <$> getAttr s
-  fontWeightAttr :: FontWeight -> String
-  fontWeightAttr FontWeightNormal = "normal"
-  fontWeightAttr FontWeightBold   = "bold"
-
-renderFontFamily' :: SVGFloat n => Style v n -> [Attribute]
-renderFontFamily' s = renderAttr' fontFamily_ ff
+renderFontFamily :: SVGFloat n => Style v n -> [Attribute]
+renderFontFamily s = renderAttr fontFamily_ ff
  where
   ff = getFont <$> getAttr s
 
-renderFontFamily :: SVGFloat n => Style v n -> S.Attribute
-renderFontFamily s = renderAttr A.fontFamily fontFamily_
- where
-  fontFamily_ = getFont <$> getAttr s
-
 -- | Render a style attribute if available, empty otherwise.
-renderAttr' :: Show s => (T.Text -> Attribute)
+renderAttr :: Show s => (T.Text -> Attribute)
            -> Maybe s
            -> [Attribute]
-renderAttr' attr valM = case valM of
+renderAttr attr valM = case valM of
   Just val -> [attr (toText val)]
   Nothing  -> []
-  
-renderAttr :: S.ToValue s => (S.AttributeValue -> S.Attribute)
-           -> Maybe s
-           -> S.Attribute
-renderAttr attr valM = case valM of
-  Just val -> attr (S.toValue val)
-  Nothing  -> mempty
 
 colorToRgbText :: forall c . Color c => c -> T.Text
 colorToRgbText c = T.concat
@@ -666,17 +370,6 @@ colorToRgbText c = T.concat
   , ")"
   ]
  where int d = toText (round (d * 255) :: Int)
-       (r,g,b,_) = colorToSRGBA c
-
-colorToRgbString :: forall c . Color c => c -> String
-colorToRgbString c = concat
-  [ "rgb("
-  , int r, ","
-  , int g, ","
-  , int b
-  , ")"
-  ]
- where int d = show (round (d * 255) :: Int)
        (r,g,b,_) = colorToSRGBA c
 
 colorToOpacity :: forall c . Color c => c -> Double

--- a/src/Graphics/Rendering/SVG.hs
+++ b/src/Graphics/Rendering/SVG.hs
@@ -87,10 +87,10 @@ svgHeader :: SVGFloat n => n -> n -> [Attribute] -> SvgM -> SvgM
 svgHeader w h defines s =  doctype_ <> with (svg11_ (g_  defines s))
   [ width_  (toText w)
   , height_ (toText h)
-  , fontSize_ "1"
+  , font_size_ "1"
   , viewBox_ (pack . unwords $ map show ([0, 0, round w, round h] :: [Int]))
   , stroke_ "rgb(0,0,0)"
-  , strokeOpacity_ "1" ]
+  , stroke_opacity_ "1" ]
 
 renderPath :: SVGFloat n => Path V2 n -> SvgM
 renderPath trs = if makePath == T.empty then mempty else path_ [d_ makePath]
@@ -128,9 +128,9 @@ renderClip p ident svg =
 
 renderStop :: SVGFloat n => GradientStop n -> SvgM
 renderStop (GradientStop c v)
-  = stop_ [ stopColor_   (colorToRgbText c)
+  = stop_ [ stop_color_   (colorToRgbText c)
           , offset_      (toText v)
-          , stopOpacity_ (toText $ colorToOpacity c) ]
+          , stop_opacity_ (toText $ colorToOpacity c) ]
 
 spreadMethodText :: SpreadMethod -> AttributeValue
 spreadMethodText GradPad      = "pad"
@@ -195,12 +195,12 @@ renderFillTextureDefs i s =
 renderFillTexture :: SVGFloat n => Int -> Style v n -> [Attribute]
 renderFillTexture ident s = case getNumAttr getFillTexture s of
   Just (SC (SomeColor c)) -> renderTextAttr fill_ fillColorRgb <>
-                             renderAttr fillOpacity_ fillColorOpacity
+                             renderAttr fill_opacity_ fillColorOpacity
     where
       fillColorRgb     = Just $ colorToRgbText c
       fillColorOpacity = Just $ colorToOpacity c
-  Just (LG _) -> [fill_ ("url(#gradient" <> toText ident <> ")"), fillOpacity_ "1"]
-  Just (RG _) -> [fill_ ("url(#gradient" <> toText ident <> ")"), fillOpacity_ "1"]
+  Just (LG _) -> [fill_ ("url(#gradient" <> toText ident <> ")"), fill_opacity_ "1"]
+  Just (RG _) -> [fill_ ("url(#gradient" <> toText ident <> ")"), fill_opacity_ "1"]
   Nothing     -> []
 
 renderLineTextureDefs :: SVGFloat n => Int -> Style v n -> SvgM
@@ -213,12 +213,12 @@ renderLineTextureDefs i s =
 renderLineTexture :: SVGFloat n => Int -> Style v n -> [Attribute]
 renderLineTexture ident s = case getNumAttr getLineTexture s of
   Just (SC (SomeColor c)) -> renderTextAttr stroke_ lineColorRgb <>
-                             renderAttr strokeOpacity_ lineColorOpacity
+                             renderAttr stroke_opacity_ lineColorOpacity
     where
       lineColorRgb     = Just $ colorToRgbText c
       lineColorOpacity = Just $ colorToOpacity c
-  Just (LG _) -> [stroke_ ("url(#gradient" <> toText ident <> ")"), strokeOpacity_ "1"]
-  Just (RG _) -> [stroke_ ("url(#gradient" <> toText ident <> ")"), strokeOpacity_ "1"]
+  Just (LG _) -> [stroke_ ("url(#gradient" <> toText ident <> ")"), stroke_opacity_ "1"]
+  Just (RG _) -> [stroke_ ("url(#gradient" <> toText ident <> ")"), stroke_opacity_ "1"]
   Nothing     -> []
 
 dataUri :: String -> BS8.ByteString -> AttributeValue
@@ -250,8 +250,8 @@ renderText :: SVGFloat n => Text n -> SvgM
 renderText (Text tt tAlign str) =
   text_
     [ transform_ transformMatrix
-    , dominantBaseline_ vAlign
-    , textAnchor_ hAlign
+    , dominant_baseline_ vAlign
+    , text_anchor_ hAlign
     , stroke_ "none" ]
     $ toHtml str
  where
@@ -288,7 +288,7 @@ renderStyles fillId lineId s = concatMap ($ s) $
   , renderMiterLimit ]
 
 renderMiterLimit :: SVGFloat n => Style v n -> [Attribute]
-renderMiterLimit s = renderAttr strokeMiterlimit_ miterLimit
+renderMiterLimit s = renderAttr stroke_miterlimit_ miterLimit
  where miterLimit = getLineMiterLimit <$> getAttr s
 
 renderOpacity :: SVGFloat n => Style v n -> [Attribute]
@@ -296,18 +296,18 @@ renderOpacity s = renderAttr opacity_ o
  where o = getOpacity <$> getAttr s
 
 renderFillRule :: SVGFloat n => Style v n -> [Attribute]
-renderFillRule s = renderTextAttr fillRule_ fr
+renderFillRule s = renderTextAttr fill_rule_ fr
   where fr = (fillRuleToText . getFillRule) <$> getAttr s
         fillRuleToText :: FillRule -> AttributeValue
         fillRuleToText Winding = "nonzero"
         fillRuleToText EvenOdd = "evenodd"
 
 renderLineWidth :: SVGFloat n => Style v n -> [Attribute]
-renderLineWidth s = renderAttr strokeWidth_ lWidth
+renderLineWidth s = renderAttr stroke_width_ lWidth
   where lWidth = getNumAttr getLineWidth s
 
 renderLineCap :: SVGFloat n => Style v n -> [Attribute]
-renderLineCap s = renderTextAttr strokeLinecap_ lCap
+renderLineCap s = renderTextAttr stroke_linecap_ lCap
   where lCap = (lineCapToText . getLineCap) <$> getAttr s
         lineCapToText :: LineCap -> AttributeValue
         lineCapToText LineCapButt   = "butt"
@@ -315,7 +315,7 @@ renderLineCap s = renderTextAttr strokeLinecap_ lCap
         lineCapToText LineCapSquare = "square"
 
 renderLineJoin :: SVGFloat n => Style v n -> [Attribute]
-renderLineJoin s = renderTextAttr strokeLinejoin_ lj
+renderLineJoin s = renderTextAttr stroke_linejoin_ lj
   where lj = (lineJoinToText . getLineJoin) <$> getAttr s
         lineJoinToText :: LineJoin -> AttributeValue
         lineJoinToText LineJoinMiter = "miter"
@@ -323,8 +323,8 @@ renderLineJoin s = renderTextAttr strokeLinejoin_ lj
         lineJoinToText LineJoinBevel = "bevel"
 
 renderDashing :: SVGFloat n => Style v n -> [Attribute]
-renderDashing s = renderTextAttr strokeDasharray_ arr <>
-                  renderAttr strokeDashoffset_ dOffset
+renderDashing s = renderTextAttr stroke_dasharray_ arr <>
+                  renderAttr stroke_dashoffset_ dOffset
  where
   getDasharray  (Dashing a _) = a
   getDashoffset (Dashing _ o) = o
@@ -334,12 +334,12 @@ renderDashing s = renderTextAttr strokeDasharray_ arr <>
   dOffset                     = getDashoffset <$> dashing'
 
 renderFontSize :: SVGFloat n => Style v n -> [Attribute]
-renderFontSize s = renderTextAttr fontSize_ fs
+renderFontSize s = renderTextAttr font_size_ fs
  where
   fs = pack <$> getNumAttr ((++ "px") . show . getFontSize) s
 
 renderFontSlant :: SVGFloat n => Style v n -> [Attribute]
-renderFontSlant s = renderTextAttr fontStyle_ fs
+renderFontSlant s = renderTextAttr font_style_ fs
  where
   fs = (fontSlantAttr . getFontSlant) <$> getAttr s
   fontSlantAttr :: FontSlant -> AttributeValue
@@ -348,7 +348,7 @@ renderFontSlant s = renderTextAttr fontStyle_ fs
   fontSlantAttr FontSlantNormal  = "normal"
 
 renderFontWeight :: SVGFloat n => Style v n -> [Attribute]
-renderFontWeight s = renderTextAttr fontWeight_ fw
+renderFontWeight s = renderTextAttr font_weight_ fw
  where
   fw = (fontWeightAttr . getFontWeight) <$> getAttr s
   fontWeightAttr :: FontWeight -> AttributeValue
@@ -356,7 +356,7 @@ renderFontWeight s = renderTextAttr fontWeight_ fw
   fontWeightAttr FontWeightBold   = "bold"
 
 renderFontFamily :: SVGFloat n => Style v n -> [Attribute]
-renderFontFamily s = renderTextAttr  fontFamily_ ff
+renderFontFamily s = renderTextAttr  font_family_ ff
  where
   ff = (pack . getFont) <$> getAttr s
 


### PR DESCRIPTION
# Ready to Merge

This branch is a port of diagrams-svg to use lucid-svg, instead of blaze-svg.
I wrote the lucid-svg library after reading Chris Done's blog posts http://chrisdone.com/posts/lucid
and http://chrisdone.com/posts/lucid2, which do a good job of explaining why he created Lucid as
an alternative to blaze-html. Most of the advantages he discusses there, apply equally to lucid-svg.
But to summarize we get
* No name conflicts with base allowing us to use Lucid.Svg unqualified
* Consistent naming for elements and attributes, and no name clashes do to polymorphism.
* A real monad instance
* Better syntax and composition of attributes
* A single package to import
* Monoidal and monadic interface

In addition, we get complete control over lucid-svg (although, I suspect that since byorgey was the most
recent uploader of blaze-svg, we probably have pretty good control there too). and a small lightweight
framework.

The disadvantages are,
* Blaze is slightly faster
* diagrams-svg using blaze has been battle tested

Please let me know your thoughts and if you get a chance run it through some test diagrams.

@bergey , @byorgey , @fryguybob , @cchalmers 