### PR TITLE
Allow user to set ID prefixes

### DIFF
--- a/src/Diagrams/Backend/SVG/CmdLine.hs
+++ b/src/Diagrams/Backend/SVG/CmdLine.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE ConstraintKinds      #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -173,7 +174,7 @@ chooseRender opts pretty d =
     [""] -> putStrLn "No output file given."
     ps | last ps `elem` ["svg"] -> do
            let szSpec = fromIntegral <$> mkSizeSpec2D (opts^.width) (opts^.height)
-               build  = renderDia SVG (SVGOptions szSpec []) d
+               build  = renderDia SVG (SVGOptions szSpec [] "") d
            if isPretty pretty
              then LT.writeFile (opts^.output) (prettyText build)
              else BS.writeFile (opts^.output) (renderBS build)

--- a/src/Graphics/Rendering/SVG.hs
+++ b/src/Graphics/Rendering/SVG.hs
@@ -119,12 +119,12 @@ renderSeg (Cubic  (V2 x0 y0)
                   (V2 x1 y1)
                   (OffsetClosed (V2 x2 y2))) = cR x0 y0 x1 y1 x2 y2
 
-renderClip :: SVGFloat n => Path V2 n -> Int -> SvgM -> SvgM
-renderClip p ident svg =
+renderClip :: SVGFloat n => Path V2 n -> T.Text -> Int -> SvgM -> SvgM
+renderClip p prefix ident svg =
   g_  [clip_path_ $ ("url(#" <> clipPathId ident <> ")")] $ do
     clipPath_ [id_ (clipPathId ident)] (renderPath p)
     svg
-  where clipPathId i = "myClip" <> (toText i)
+  where clipPathId i = prefix <> "myClip" <> (toText i)
 
 renderStop :: SVGFloat n => GradientStop n -> SvgM
 renderStop (GradientStop c v)


### PR DESCRIPTION
Without this, separately generated diagrams displayed on the same page can
conflict and display incorrectly.