### PR TITLE
Rough draft at adding support for SVG node ids

### DIFF
--- a/diagrams-svg.cabal
+++ b/diagrams-svg.cabal
@@ -61,6 +61,7 @@ Library
                      , lens                 >= 4.0   && < 4.12
                      , hashable             >= 1.1   && < 1.3
                      , optparse-applicative >= 0.10  && < 0.12
+                     , semigroups
   if impl(ghc < 7.6)
     build-depends:     ghc-prim
 

--- a/diagrams-svg.cabal
+++ b/diagrams-svg.cabal
@@ -62,7 +62,7 @@ Library
                      , lens                 >= 4.0   && < 4.12
                      , hashable             >= 1.1   && < 1.3
                      , optparse-applicative >= 0.10  && < 0.12
-                     , semigroups
+                     , semigroups           >= 0.13  && < 0.17
   if impl(ghc < 7.6)
     build-depends:     ghc-prim
 

--- a/diagrams-svg.cabal
+++ b/diagrams-svg.cabal
@@ -38,6 +38,7 @@ Source-repository head
 Library
   Exposed-modules:     Diagrams.Backend.SVG
                        Diagrams.Backend.SVG.CmdLine
+                       Diagrams.Backend.SVG.Attributes
   Other-modules:       Graphics.Rendering.SVG
   Hs-source-dirs:      src
   Build-depends:       base                 >= 4.3   && < 4.9

--- a/src/Diagrams/Backend/SVG/Attributes.hs
+++ b/src/Diagrams/Backend/SVG/Attributes.hs
@@ -22,3 +22,14 @@ instance AttributeClass SvgId
 
 svgId :: HasStyle a => Text -> a -> a
 svgId val a = applyAttr (SvgId val) a
+
+
+data SvgClass = SvgClass {getSvgClass :: Text}
+  deriving (Typeable)
+instance Semigroup SvgClass where 
+  _ <> a = a
+instance AttributeClass SvgClass
+
+svgClass :: HasStyle a => Text -> a -> a
+svgClass val a = applyAttr (SvgClass val) a
+

--- a/src/Diagrams/Backend/SVG/Attributes.hs
+++ b/src/Diagrams/Backend/SVG/Attributes.hs
@@ -1,0 +1,24 @@
+{-| Attributes that are specific to the SVG backend. The intent
+    of this module is to allow adding attributes like class,
+    id, and data attributes to an SVG. For those embedding 
+    the resulting SVG into a webpage, this allows some 
+    interactivity with javascript and stylesheets.
+-}
+
+{-# LANGUAGE DeriveDataTypeable #-}
+
+module Diagrams.Backend.SVG.Attributes where
+
+import Data.Text (Text)
+import Data.Semigroup
+import Diagrams.Core.Style (AttributeClass,HasStyle,applyAttr)
+import Data.Typeable (Typeable)
+
+data SvgId = SvgId {getSvgId :: Text}
+  deriving (Typeable)
+instance Semigroup SvgId where 
+  _ <> a = a
+instance AttributeClass SvgId
+
+svgId :: HasStyle a => Text -> a -> a
+svgId val a = applyAttr (SvgId val) a

--- a/src/Diagrams/Backend/SVG/Attributes.hs
+++ b/src/Diagrams/Backend/SVG/Attributes.hs
@@ -9,27 +9,26 @@
 
 module Diagrams.Backend.SVG.Attributes where
 
-import Data.Text (Text)
 import Data.Semigroup
 import Diagrams.Core.Style (AttributeClass,HasStyle,applyAttr)
 import Data.Typeable (Typeable)
 
-data SvgId = SvgId {getSvgId :: Text}
+data SvgId = SvgId {getSvgId :: String}
   deriving (Typeable)
 instance Semigroup SvgId where 
   _ <> a = a
 instance AttributeClass SvgId
 
-svgId :: HasStyle a => Text -> a -> a
+svgId :: HasStyle a => String -> a -> a
 svgId val a = applyAttr (SvgId val) a
 
 
-data SvgClass = SvgClass {getSvgClass :: Text}
+data SvgClass = SvgClass {getSvgClass :: String}
   deriving (Typeable)
 instance Semigroup SvgClass where 
   _ <> a = a
 instance AttributeClass SvgClass
 
-svgClass :: HasStyle a => Text -> a -> a
+svgClass :: HasStyle a => String -> a -> a
 svgClass val a = applyAttr (SvgClass val) a
 

--- a/src/Graphics/Rendering/SVG.hs
+++ b/src/Graphics/Rendering/SVG.hs
@@ -303,7 +303,7 @@ renderSvgId s = renderTextAttr id_ svgIdAttr
  where svgIdAttr = getSvgId <$> getAttr s
 
 renderSvgClass :: SVGFloat n => Style v n -> [Attribute]
-renderSvgClass s = renderTextAttr id_ svgClassAttr
+renderSvgClass s = renderTextAttr class_ svgClassAttr
  where svgClassAttr = getSvgClass <$> getAttr s
 
 renderMiterLimit :: SVGFloat n => Style v n -> [Attribute]

--- a/src/Graphics/Rendering/SVG.hs
+++ b/src/Graphics/Rendering/SVG.hs
@@ -300,11 +300,11 @@ renderStyles fillId lineId s = concatMap ($ s) $
 
 renderSvgId :: SVGFloat n => Style v n -> [Attribute]
 renderSvgId s = renderTextAttr id_ svgIdAttr
- where svgIdAttr = getSvgId <$> getAttr s
+ where svgIdAttr = pack . getSvgId <$> getAttr s
 
 renderSvgClass :: SVGFloat n => Style v n -> [Attribute]
 renderSvgClass s = renderTextAttr class_ svgClassAttr
- where svgClassAttr = getSvgClass <$> getAttr s
+ where svgClassAttr = pack . getSvgClass <$> getAttr s
 
 renderMiterLimit :: SVGFloat n => Style v n -> [Attribute]
 renderMiterLimit s = renderAttr stroke_miterlimit_ miterLimit

--- a/src/Graphics/Rendering/SVG.hs
+++ b/src/Graphics/Rendering/SVG.hs
@@ -71,7 +71,7 @@ import qualified Data.ByteString.Lazy.Char8  as BS8
 import           Codec.Picture
 
 -- from same package
-import Diagrams.Backend.SVG.Attributes       (SvgId(..))
+import Diagrams.Backend.SVG.Attributes       (SvgId(..),SvgClass(..))
 
 -- | Constaint on number type that diagrams-svg can use to render an SVG. This
 --   includes the common number types: Double, Float
@@ -294,12 +294,17 @@ renderStyles fillId lineId s = concatMap ($ s) $
   , renderFontWeight
   , renderFontFamily
   , renderSvgId
+  , renderSvgClass
   , renderMiterLimit ]
 
 
 renderSvgId :: SVGFloat n => Style v n -> [Attribute]
 renderSvgId s = renderTextAttr id_ svgIdAttr
  where svgIdAttr = getSvgId <$> getAttr s
+
+renderSvgClass :: SVGFloat n => Style v n -> [Attribute]
+renderSvgClass s = renderTextAttr id_ svgClassAttr
+ where svgClassAttr = getSvgClass <$> getAttr s
 
 renderMiterLimit :: SVGFloat n => Style v n -> [Attribute]
 renderMiterLimit s = renderAttr stroke_miterlimit_ miterLimit

--- a/src/Graphics/Rendering/SVG.hs
+++ b/src/Graphics/Rendering/SVG.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes        #-}
 {-# LANGUAGE ViewPatterns      #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -45,6 +46,7 @@ import           Data.Foldable               (foldMap)
 
 import           Data.Maybe                  (fromMaybe)
 import           Data.Monoid
+import           Data.Typeable               (Typeable)
 
 -- from diagrams-core
 import           Diagrams.Core.Transform     (matrixHomRep)
@@ -68,6 +70,9 @@ import qualified Data.ByteString.Lazy.Char8  as BS8
 
 -- from JuicyPixels
 import           Codec.Picture
+
+-- from semigroups
+import qualified Data.Semigroup              as S 
 
 -- | Constaint on number type that diagrams-svg can use to render an SVG. This
 --   includes the common number types: Double, Float
@@ -289,7 +294,21 @@ renderStyles fillId lineId s = concatMap ($ s) $
   , renderFontSlant
   , renderFontWeight
   , renderFontFamily
+  , renderNodeId
   , renderMiterLimit ]
+
+data NodeId = NodeId {getNodeId :: T.Text}
+  deriving (Typeable)
+instance Semigroup NodeId where 
+  _ <> a = a
+instance AttributeClass NodeId
+
+nodeId :: HasStyle a => T.Text -> a -> a
+nodeId val a = applyAttr (NodeId val) a
+
+renderNodeId :: SVGFloat n => Style v n -> [Attribute]
+renderNodeId s = renderTextAttr id_ nodeIdAttr
+ where nodeIdAttr = getNodeId <$> getAttr s
 
 renderMiterLimit :: SVGFloat n => Style v n -> [Attribute]
 renderMiterLimit s = renderAttr stroke_miterlimit_ miterLimit

--- a/src/Graphics/Rendering/SVG.hs
+++ b/src/Graphics/Rendering/SVG.hs
@@ -46,7 +46,6 @@ import           Data.Foldable               (foldMap)
 
 import           Data.Maybe                  (fromMaybe)
 import           Data.Monoid
-import           Data.Typeable               (Typeable)
 
 -- from diagrams-core
 import           Diagrams.Core.Transform     (matrixHomRep)
@@ -71,8 +70,8 @@ import qualified Data.ByteString.Lazy.Char8  as BS8
 -- from JuicyPixels
 import           Codec.Picture
 
--- from semigroups
-import qualified Data.Semigroup              as S 
+-- from same package
+import Diagrams.Backend.SVG.Attributes       (SvgId(..))
 
 -- | Constaint on number type that diagrams-svg can use to render an SVG. This
 --   includes the common number types: Double, Float
@@ -294,21 +293,13 @@ renderStyles fillId lineId s = concatMap ($ s) $
   , renderFontSlant
   , renderFontWeight
   , renderFontFamily
-  , renderNodeId
+  , renderSvgId
   , renderMiterLimit ]
 
-data NodeId = NodeId {getNodeId :: T.Text}
-  deriving (Typeable)
-instance Semigroup NodeId where 
-  _ <> a = a
-instance AttributeClass NodeId
 
-nodeId :: HasStyle a => T.Text -> a -> a
-nodeId val a = applyAttr (NodeId val) a
-
-renderNodeId :: SVGFloat n => Style v n -> [Attribute]
-renderNodeId s = renderTextAttr id_ nodeIdAttr
- where nodeIdAttr = getNodeId <$> getAttr s
+renderSvgId :: SVGFloat n => Style v n -> [Attribute]
+renderSvgId s = renderTextAttr id_ svgIdAttr
+ where svgIdAttr = getSvgId <$> getAttr s
 
 renderMiterLimit :: SVGFloat n => Style v n -> [Attribute]
 renderMiterLimit s = renderAttr stroke_miterlimit_ miterLimit


### PR DESCRIPTION
I would like to get some feedback this preliminary PR to add svg node ids. Here are relevant channels where this has been discussed a little bit already:

  - http://stackoverflow.com/questions/30925400/setting-id-and-class-with-the-haskell-diagrams-package
  - http://www.reddit.com/r/haskell/comments/3absht/setting_id_and_class_with_the_haskell_diagrams/

What I have done so far is just add everything to `Graphics/Rendering/SVG.hs`, which is definitely bad, but I just wanted it to be easily visible for the time being. Here are some things I'd like to hear more experienced opinions on:

  - Where do things belong? It seems like `renderNodeId` should stay where it is. But, where do I put `NodeId` (with the instances) and `nodeId`. I would rather see them in `diagrams-svg` than anywhere else because they are backend-specific. Would it be better to create a new module for them?
  - Right now, `nodeId` has the type `HasStyle a => T.Text -> a -> a`. To be more correct, we could constrain `a` even further to make this only work with SVG diagrams. If someone could tell me what that type to use, that would be appreciated.
  - Is `NodeId` the most suitable name for this? I'm very open to other suggestions.

I'm planning on adding `NodeClass` as well after I get some more direction. Thanks.