### PR TITLE
Add `generateDoctype, idAttr, and style` to SVGOptions

### DIFF
--- a/src/Diagrams/Backend/SVG.hs
+++ b/src/Diagrams/Backend/SVG.hs
@@ -229,7 +229,9 @@ svgHeader w h defines idAttr' style' generateDoctype' s = do
               , viewBox_ (pack . unwords $ map show ([0, 0, round w, round h] :: [Int]))
               , stroke_ "rgb(0,0,0)"
               , stroke_opacity_ "1"
-              ] ++ [id_ idAttr', A.style_ style']
+              ]
+              ++ if (not $ T.null idAttr') then [id_ idAttr']     else []
+              ++ if (not $ T.null style')  then [A.style_ style'] else []
   (`with` attrs) $ svg11_ $ do
     defs_ $ fromMaybe mempty defines
     s
@@ -291,7 +293,7 @@ instance SVGFloat n => Backend SVG V2 n where
   adjustDia c opts d = adjustDia2D sizeSpec c opts (d # reflectY)
 
 defaultSVGOptions :: SVGFloat n => SizeSpec V2 n -> Options SVG V2 n
-defaultSVGOptions spec = SVGOptions spec Nothing "" "" "" True
+defaultSVGOptions spec = SVGOptions spec Nothing "" T.empty T.empty True
 
 rtree :: SVGFloat n => RTree SVG V2 n Annotation -> Render SVG V2 n
 rtree (Node n rs) = case n of

--- a/src/Diagrams/Backend/SVG.hs
+++ b/src/Diagrams/Backend/SVG.hs
@@ -94,13 +94,27 @@
 module Diagrams.Backend.SVG
   ( SVG(..) -- rendering token
   , B
-  , Options(..), sizeSpec, svgDefinitions, idPrefix -- for rendering options specific to SVG
+
+  -- for rendering options specific to SVG
+  , Options(..)
+  , defaultSVGOptions
+  , sizeSpec
+  , svgDefinitions
+  , idPrefix
+  , idAttr
+  , styleAttr
+  , generateDoctype
+
   , SVGFloat
 
   , renderSVG
   , renderSVG'
   , renderPretty
   , renderPretty'
+  , renderInnerSVG
+  , renderInnerSVG'
+  , renderInnerPretty
+  , renderInnerPretty'
   , loadImageSVG
   ) where
 
@@ -120,6 +134,8 @@ import           System.FilePath
 import           Control.Monad.Reader
 import           Control.Monad.State
 import           Data.Char
+import           Data.Maybe               (fromMaybe)
+import           Data.Monoid
 import           Data.Typeable
 
 -- from hashable
@@ -137,14 +153,19 @@ import           Diagrams.Core.Compile
 import           Diagrams.Core.Types      (Annotation (..))
 
 -- from diagrams-lib
-import           Diagrams.Prelude         hiding (Attribute, size, view, local)
+import           Diagrams.Prelude         hiding (Attribute, local, size, view,
+                                           with, (<>))
 import           Diagrams.TwoD.Adjust     (adjustDia2D)
 import           Diagrams.TwoD.Attributes (splitTextureFills)
 import           Diagrams.TwoD.Path       (Clip (Clip))
 import           Diagrams.TwoD.Text
 
+-- from text
+import           Data.Text                (pack)
+
 -- from lucid-svg
 import           Lucid.Svg
+import qualified Lucid.Svg.Attributes     as A
 
 -- from this package
 import           Graphics.Rendering.SVG   (SVGFloat, SvgM)
@@ -162,7 +183,7 @@ type instance N SVG = Double
 
 data Environment n = Environment
   { _style :: Style V2 n
-  , __pre :: T.Text
+  , __pre  :: T.Text
   }
 
 makeLenses ''Environment
@@ -195,6 +216,23 @@ instance SVGFloat n => Monoid (Render SVG V2 n) where
     svg1 <- r1
     svg2 <- r2_
     return (svg1 `mappend` svg2)
+
+-- | @svgHeader w h defs s@: @w@ width, @h@ height,
+--   @defs@ global definitions for defs sections, @s@ actual SVG content.
+svgHeader :: SVGFloat n => n -> n -> Maybe SvgM -> T.Text
+                        -> T.Text -> Bool -> SvgM -> SvgM
+svgHeader w h defines idAttr' style' generateDoctype' s = do
+  if generateDoctype' then doctype_ else mempty
+  let attrs = [ width_  (toText w)
+              , height_ (toText h)
+              , font_size_ "1"
+              , viewBox_ (pack . unwords $ map show ([0, 0, round w, round h] :: [Int]))
+              , stroke_ "rgb(0,0,0)"
+              , stroke_opacity_ "1"
+              ] ++ [id_ idAttr', A.style_ style']
+  (`with` attrs) $ svg11_ $ do
+    defs_ $ fromMaybe mempty defines
+    s
 
 -- Handle clip attributes.
 --
@@ -234,23 +272,26 @@ instance SVGFloat n => Backend SVG V2 n where
   newtype Render  SVG V2 n = R (SvgRenderM n)
   type    Result  SVG V2 n = SvgM
   data    Options SVG V2 n = SVGOptions
-    { _size           :: SizeSpec V2 n   -- ^ The requested size.
-    , _svgDefinitions :: Maybe SvgM
-                          -- ^ Custom definitions that will be added to the @defs@
-                          --   section of the output.
-    , _idPrefix       :: T.Text
+    { _size            :: SizeSpec V2 n   -- ^ The requested size.
+    , _svgDefinitions  :: Maybe SvgM
+                           -- ^ Custom definitions that will be added to the @defs@
+                           --   section of the output.
+    , _idPrefix        :: T.Text
+    , _idAttr          :: T.Text
+    , _styleAttr       :: T.Text
+    , _generateDoctype :: Bool
     }
 
+
   renderRTree :: SVG -> Options SVG V2 n -> RTree SVG V2 n Annotation -> Result SVG V2 n
-  renderRTree _ opts rt = runRenderM (opts ^.idPrefix) svgOutput
+  renderRTree _ opts rt = runRenderM (opts ^.idPrefix) r
     where
-      svgOutput = do
-        let R r    = rtree (splitTextureFills rt)
-            V2 w h = specToSize 100 (opts^.sizeSpec)
-        svg <- r
-        return $ R.svgHeader w h (opts^.svgDefinitions) svg
+      R r = rtree (splitTextureFills rt)
 
   adjustDia c opts d = adjustDia2D sizeSpec c opts (d # reflectY)
+
+defaultSVGOptions :: SVGFloat n => SizeSpec V2 n -> Options SVG V2 n
+defaultSVGOptions spec = SVGOptions spec Nothing "" "" "" True
 
 rtree :: SVGFloat n => RTree SVG V2 n Annotation -> Render SVG V2 n
 rtree (Node n rs) = case n of
@@ -276,6 +317,15 @@ svgDefinitions f opts =
 --   same web page.
 idPrefix :: SVGFloat n => Lens' (Options SVG V2 n) T.Text
 idPrefix f opts = f (_idPrefix opts) <&> \i -> opts { _idPrefix = i }
+
+idAttr :: SVGFloat n => Lens' (Options SVG V2 n) T.Text
+idAttr f opts = f (_idAttr opts) <&> \i -> opts { _idAttr = i }
+
+styleAttr :: SVGFloat n => Lens' (Options SVG V2 n) T.Text
+styleAttr f opts = f (_styleAttr opts) <&> \i -> opts { _styleAttr = i }
+
+generateDoctype :: SVGFloat n => Lens' (Options SVG V2 n) Bool
+generateDoctype f opts = f (_generateDoctype opts) <&> \i -> opts { _generateDoctype = i }
 
 -- paths ---------------------------------------------------------------
 
@@ -304,11 +354,24 @@ instance SVGFloat n => Renderable (DImage n Embedded) SVG where
 -- | Render a diagram as an SVG, writing to the specified output file
 --   and using the requested size.
 renderSVG :: SVGFloat n => FilePath -> SizeSpec V2 n -> QDiagram SVG V2 n Any -> IO ()
-renderSVG outFile spec = renderSVG' outFile (SVGOptions spec Nothing (mkPrefix outFile))
+renderSVG outFile spec = renderSVG' outFile
+                       $ defaultSVGOptions spec & idPrefix .~ mkPrefix outFile
+
+-- | Render a diagram as SVG without a header, writing to the specified output file.
+--   Useful for including in an Html document.
+renderInnerSVG :: SVGFloat n => FilePath -> SizeSpec V2 n -> QDiagram SVG V2 n Any -> IO ()
+renderInnerSVG outFile spec = renderInnerSVG' outFile
+                            $ defaultSVGOptions spec & idPrefix .~ mkPrefix outFile
 
 -- | Render a diagram as a pretty printed SVG.
 renderPretty :: SVGFloat n => FilePath -> SizeSpec V2 n -> QDiagram SVG V2 n Any -> IO ()
-renderPretty outFile spec = renderPretty' outFile (SVGOptions spec Nothing (mkPrefix outFile))
+renderPretty outFile spec = renderPretty' outFile
+                          $ defaultSVGOptions spec & idPrefix .~ mkPrefix outFile
+
+-- | Render a diagram as a pretty printed SVG without a header.
+renderInnerPretty :: SVGFloat n => FilePath -> SizeSpec V2 n -> QDiagram SVG V2 n Any -> IO ()
+renderInnerPretty outFile spec = renderInnerPretty' outFile
+                               $ defaultSVGOptions spec & idPrefix .~ mkPrefix outFile
 
 -- Create a prefile using the basename of the output file. Only standard
 -- letters are considered.
@@ -319,13 +382,31 @@ mkPrefix = T.filter isAlpha . T.pack . takeBaseName
 --   and using the backend options. The id prefix is derived from the
 --   basename of the output file.
 renderSVG' :: SVGFloat n => FilePath -> Options SVG V2 n -> QDiagram SVG V2 n Any -> IO ()
-renderSVG' outFile opts = BS.writeFile outFile . renderBS . renderDia SVG opts
+renderSVG' outFile opts = BS.writeFile outFile . renderBS . withHeader . renderDia SVG opts
+  where
+    V2 w h = specToSize 100 (opts^.sizeSpec)
+    withHeader = svgHeader w h (opts^.svgDefinitions) (opts^.idAttr)
+                               (opts^.styleAttr) (opts^.generateDoctype)
 
 -- | Render a diagram as a pretty printed SVG to the specified output
 --   file and using the backend options. The id prefix is derived from the
 --   basename of the output file.
 renderPretty' :: SVGFloat n => FilePath -> Options SVG V2 n -> QDiagram SVG V2 n Any -> IO ()
-renderPretty' outFile opts = LT.writeFile outFile . prettyText . renderDia SVG opts
+renderPretty' outFile opts = LT.writeFile outFile . prettyText . withHeader . renderDia SVG opts
+  where
+    V2 w h = specToSize 100 (opts^.sizeSpec)
+    withHeader = svgHeader w h (opts^.svgDefinitions) (opts^.idAttr)
+                               (opts^.styleAttr) (opts^.generateDoctype)
+
+-- | Render a diagram as SVG without a header, writing to the specified output file
+--   and the backend options. Useful for including in an Html document.
+renderInnerSVG' :: SVGFloat n => FilePath -> Options SVG V2 n -> QDiagram SVG V2 n Any -> IO ()
+renderInnerSVG' outFile opts = BS.writeFile outFile . renderBS . renderDia SVG opts
+
+-- | Render a diagram as pretty printed SVG without a header, writing to the specified output file
+--   and the backend options. Useful for including in an Html document.
+renderInnerPretty' :: SVGFloat n => FilePath -> Options SVG V2 n -> QDiagram SVG V2 n Any -> IO ()
+renderInnerPretty' outFile opts = LT.writeFile outFile . prettyText . renderDia SVG opts
 
 data Img = Img !Char !BS.ByteString deriving Typeable
 
@@ -359,5 +440,10 @@ instance SVGFloat n => Renderable (DImage n (Native Img)) SVG where
     return $ R.renderDImage di $ R.dataUri mime d
 
 instance (Hashable n, SVGFloat n) => Hashable (Options SVG V2 n) where
-  hashWithSalt s  (SVGOptions sz defs _) = s `hashWithSalt` sz `hashWithSalt` ds
+  hashWithSalt s  (SVGOptions sz defs ia sa _ rg) =
+    s  `hashWithSalt`
+    sz `hashWithSalt`
+    ds `hashWithSalt`
+    ia `hashWithSalt`
+    sa `hashWithSalt` rg
     where ds = fmap renderBS defs

--- a/src/Graphics/Rendering/SVG.hs
+++ b/src/Graphics/Rendering/SVG.hs
@@ -22,7 +22,6 @@ module Graphics.Rendering.SVG
     ( SVGFloat
     , SvgM
     , AttributeValue
-    , svgHeader
     , renderPath
     , renderClip
     , renderText
@@ -44,15 +43,13 @@ import           Data.List                   (intercalate)
 import           Data.Foldable               (foldMap)
 #endif
 
-import           Data.Maybe                  (fromMaybe)
 import           Data.Monoid
 
 -- from diagrams-core
 import           Diagrams.Core.Transform     (matrixHomRep)
 
 -- from diagrams-lib
-import           Diagrams.Prelude            hiding (Attribute, Render, with,
-                                              (<>))
+import           Diagrams.Prelude            hiding (Attribute, Render, (<>))
 import           Diagrams.TwoD.Path          (getFillRule)
 import           Diagrams.TwoD.Text
 
@@ -87,19 +84,6 @@ type AttributeValue = T.Text
 
 getNumAttr :: AttributeClass (a n) => (a n -> t) -> Style v n -> Maybe t
 getNumAttr f = (f <$>) . getAttr
-
--- | @svgHeader w h defs s@: @w@ width, @h@ height,
---   @defs@ global definitions for defs sections, @s@ actual SVG content.
-svgHeader :: SVGFloat n => n -> n -> Maybe SvgM -> SvgM -> SvgM
-svgHeader w h defines s =  doctype_ <> with (svg11_ (defs_  ds <> s))
-  [ width_  (toText w)
-  , height_ (toText h)
-  , font_size_ "1"
-  , viewBox_ (pack . unwords $ map show ([0, 0, round w, round h] :: [Int]))
-  , stroke_ "rgb(0,0,0)"
-  , stroke_opacity_ "1" ]
-  where
-    ds = fromMaybe mempty defines
 
 renderPath :: SVGFloat n => Path V2 n -> SvgM
 renderPath trs = if makePath == T.empty then mempty else path_ [d_ makePath]


### PR DESCRIPTION
# Needs testing and review before merge

As per: https://github.com/ryantrinkle/diagrams-svg/tree/more-options

Also provide the ability to output SVG without a header.

## This is a breaking change only for code that uses `renderDia` directly.