### PR TITLE
Reduce size of SVG files by applying attriubtes in groups

### DIFF
--- a/src/Graphics/Rendering/SVG.hs
+++ b/src/Graphics/Rendering/SVG.hs
@@ -34,6 +34,7 @@ module Graphics.Rendering.SVG
     , renderFillTexture
     , renderLineTextureDefs
     , renderLineTexture
+    , renderOpacity
     , dataUri
     , getNumAttr
     ) where
@@ -294,7 +295,6 @@ renderStyles fillId lineId s = concatMap ($ s) $
   , renderLineJoin
   , renderFillRule
   , renderDashing
-  , renderOpacity
   , renderFontSize
   , renderFontSlant
   , renderFontWeight


### PR DESCRIPTION
# Please Don't Merge

The basic idea is that since all transformations have already been applied once we convert to an `RTree`, we don't need to push all of the styles down to the leaves. Instead we can simply create an SVG group element that contains the style and any children nodes of the `RTree`.

I'm getting file size reductions by factors of up to of 7 or 8 on
highly recursive diagrams like the Pentaflake.

So far I've ran the backend tests plus:
 - clipping
 - gradients
 - arrows
 - kaleidoscope, pentaflake, hilbert and a few others.

