### PR TITLE
fix `adjustDia` Transformation

### DIFF
--- a/src/Diagrams/Backend/SVG.hs
+++ b/src/Diagrams/Backend/SVG.hs
@@ -257,7 +257,8 @@ instance SVGFloat n => Backend SVG V2 n where
                                  (opts^.svgAttributes)
                                  (opts^.generateDoctype) svg
 
-  adjustDia c opts d = adjustDia2D sizeSpec c opts (d # reflectY)
+  adjustDia c opts d = ( sz, t <> reflectionY, d' ) where
+    (sz, t, d') = adjustDia2D sizeSpec c opts (d # reflectY)
 
 rtree :: SVGFloat n => RTree SVG V2 n Annotation -> Render SVG V2 n
 rtree (Node n rs) = case n of


### PR DESCRIPTION
SVG has +Y down, DIagrams has +Y up.  We fix rendering by calling
`reflectY` on the Diagram in `adjustDia`.  The Transformation returned
from `adjustDia` needs to include this reflection.

closes #89