### PR TITLE
Update docs in SVG.hs to reflect svg-builder

### DIFF
--- a/src/Diagrams/Backend/SVG.hs
+++ b/src/Diagrams/Backend/SVG.hs
@@ -89,9 +89,9 @@
 -- situations GHC may not be able to infer the type @m@, in which case
 -- you can use a type annotation to specify it; it may be useful to
 -- simply use the type synonym @Diagram SVG = QDiagram SVG V2 Double
--- Any@.) This returns an 'Graphics.Rendering.SVG.Element' value, which
--- you can, /e.g./ render to a 'ByteString' using 'Lucid.Svg.renderBS'
--- from the 'lucid-svg' package.
+-- Any@.) This returns an 'Graphics.Svg.Core.Element' value, which
+-- you can, /e.g./ render to a 'ByteString' using 'Graphics.Svg.Core.renderBS'
+-- from the 'svg-builder' package.
 --
 -----------------------------------------------------------------------------
 


### PR DESCRIPTION
I believe we've moved to `svg-builder`, so we should update the references from `lucid-svg` to `svg-builder`.

By the way, both the `Element` type and the `renderBS` function actually reside in `Graphics.Svg.Core`, but are also re-exported by `Graphics.Svg`. I thought it makes more sense to write `Graphics.Svg.Core` here. Is this the right way to refer to the type and function?