### PR TITLE
Add type signature to example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A simple example that uses _diagrams-svg_ to draw a square.
 import Diagrams.Prelude
 import Diagrams.Backend.SVG.CmdLine
 
+b1 :: Diagram B
 b1 = square 20 # lw 0.002
 
 main = mainWith (pad 1.1 b1)


### PR DESCRIPTION
Without the type signature I was getting errors like:
```
    test.hs:8:8: error:
        • Ambiguous type variables ‘b0’, ‘n0’, ‘m0’ arising from a use of ‘mainWith’
          prevents the constraint ‘(Diagrams.Backend.CmdLine.Mainable
                                      (QDiagram b0 V2 n0 m0))’ from being solved.
          Probable fix: use a type annotation to specify what ‘b0’, ‘n0’, ‘m0’ should be.
          These potential instance exist:
            instance diagrams-svg-1.4.1:Graphics.Rendering.SVG.SVGFloat n =>
                     Diagrams.Backend.CmdLine.Mainable (QDiagram SVG V2 n Any)
              -- Defined in ‘Diagrams.Backend.SVG.CmdLine’
        • In the expression: mainWith (pad 1.1 b1)
          In an equation for ‘main’: main = mainWith (pad 1.1 b1)
```