### PR TITLE
Bump base bound for GHC 8.2

### DIFF
--- a/diagrams-svg.cabal
+++ b/diagrams-svg.cabal
@@ -40,7 +40,7 @@ Library
                        Diagrams.Backend.SVG.CmdLine
   Other-modules:       Graphics.Rendering.SVG
   Hs-source-dirs:      src
-  Build-depends:       base                 >= 4.3   && < 4.10
+  Build-depends:       base                 >= 4.3   && < 4.11
                      , filepath
                      , mtl                  >= 1     && < 2.3
                      , bytestring           >= 0.9   && < 1.0


### PR DESCRIPTION
GHC 8.2 ships with base-4.10.
The package still builds after this change.