### PR TITLE
Allow base 4.15 for GHC 8.10

### DIFF
--- a/diagrams-svg.cabal
+++ b/diagrams-svg.cabal
@@ -40,7 +40,7 @@ Library
                        Diagrams.Backend.SVG.CmdLine
   Other-modules:       Graphics.Rendering.SVG
   Hs-source-dirs:      src
-  Build-depends:       base                 >= 4.7   && < 4.14
+  Build-depends:       base                 >= 4.7   && < 4.15
                      , filepath
                      , mtl                  >= 1     && < 2.3
                      , bytestring           >= 0.9   && < 1.0


### PR DESCRIPTION
This depends on:

- https://github.com/diagrams/svg-builder/pull/12
- [master of monoid-extras](https://github.com/diagrams/monoid-extras)
- https://github.com/diagrams/active/pull/31
- https://github.com/diagrams/diagrams-lib/pull/349
- https://github.com/diagrams/dual-tree/pull/13
- https://github.com/diagrams/diagrams-core/pull/113

For anyone else who needs to use this package (and all of its deps) with GHC 8.10, here's a `cabal.project` that works:

```
packages: .

source-repository-package
    type: git
    location: https://github.com/sjakobi/svg-builder
    tag: ff3a4b0fdfcdf8cfa0d08564733024b63121bd65

source-repository-package
    type: git
    location: https://github.com/diagrams/monoid-extras
    tag: 216a82109c38bf0c692b32db11a424bcb0b54f8e

source-repository-package
    type: git
    location: https://github.com/TravisWhitaker/active
    tag:8e5f8d7ebf12970dbe65c5df36e44c12f9b221ab

source-repository-package
    type: git
    location: https://github.com/thielema/diagrams-lib
    tag: 2d06dfca86292b454cc0041aef6e68b646237f3d

source-repository-package
    type: git
    location: https://github.com/TravisWhitaker/dual-tree
    tag: bd8e5b75f7e117420ade237e62a025a511361061

source-repository-package
    type: git
    location: https://github.com/TravisWhitaker/diagrams-core
    tag: a9456cf1c6cd3aff2c4dbf095df6dec6e51fa21c
```