### PR TITLE
Doc: using svg-builder not lucid-svg

### DIFF
--- a/diagrams-svg.cabal
+++ b/diagrams-svg.cabal
@@ -15,7 +15,7 @@ Cabal-version:       >=1.10
 Tested-with:         GHC ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1 || ==9.2.1
 Description:         This package provides a modular backend for rendering
                      diagrams created with the diagrams EDSL to SVG
-                     files.  It uses @lucid-svg@ to be a native
+                     files.  It uses @svg-builder@ to be a native
                      Haskell backend, making it suitable for use on
                      any platform.
                      .

--- a/src/Graphics/Rendering/SVG.hs
+++ b/src/Graphics/Rendering/SVG.hs
@@ -61,7 +61,7 @@ import           Diagrams.TwoD.Text
 import           Data.Text                   (pack)
 import qualified Data.Text                   as T
 
--- from lucid-svg
+-- from svg-builder
 import           Graphics.Svg                hiding (renderText)
 
 -- from base64-bytestring, bytestring


### PR DESCRIPTION
Change references in the documentation from lucid-svg to svg-builder
keeping in sync with changes in commit 741fe6823a06c6c8bd8113cae247d0419b989cad