### PR TITLE
Resolving the mismatched attributes problem.

### DIFF
--- a/examples/opts.hs
+++ b/examples/opts.hs
@@ -8,7 +8,7 @@ svgOpt = SVGOptions {
   _size = mkSizeSpec $ V2 (Just 400) (Just 400),
   _idPrefix = T.empty,
   _svgDefinitions = Nothing,
-  _svgAttributes = [LST.preserveAspectRatio_ $ T.pack "xMinYMin"],
+  _svgAttributes = [],
   _generateDoctype = True
 }
 


### PR DESCRIPTION
First of all, thanks for all your hard work on the library. Here's an issue I found today, wondering what people think about how we should best resolve it.

I propose just a quick/temporary fix to allow people to use this sample, but wanted to PR it anyway to highlight an issue this line produces. Here is what I'm getting while compiling the code in its current shape:

```
app/Main.hs:31:42: error: [GHC-83865]
    • Couldn't match expected type ‘svg-builder-0.1.1:Graphics.Svg.Core.Attribute’
                  with actual type ‘Lucid.Svg.Attribute’
      NB: ‘svg-builder-0.1.1:Graphics.Svg.Core.Attribute’
            is defined in ‘Graphics.Svg.Core’ in package ‘svg-builder-0.1.1’
          ‘Lucid.Svg.Attribute’
            is defined in ‘Lucid.Base’ in package ‘lucid-2.11.20230408’
    • In the expression:
        Lucid.Svg.preserveAspectRatio_ $ Data.Text.pack "xMinYMin"
      In the ‘_svgAttributes’ field of a record
      In the expression:
        Diagrams.Backend.SVG.SVGOptions
          {_size = Diagrams.Prelude.mkSizeSpec
                     $ Diagrams.Prelude.V2 (Just 400) (Just 400),
           _idPrefix = Data.Text.empty, _svgDefinitions = Nothing,
           _svgAttributes = [Lucid.Svg.preserveAspectRatio_
                               $ Data.Text.pack "xMinYMin"],
           _generateDoctype = True}
   |
31 |   Diagrams.Backend.SVG._svgAttributes = [Lucid.Svg.preserveAspectRatio_ $ Data.Text.pack "xMinYMin"],
```

Looks like the types are mismatched (if I'm reading the error correctly):

* `_svgAttributes` is of type `Graphics.Svg.Core.Attribute` from package `svg-builder`

* `preserveAspectRatio_` produces values of type `Lucid.Base.Attribute` from package `lucid`

Curious what others think about how this should be best addressed.

I confirm leaving the attributes empty does work and does produce the sample circle.