### PR TITLE
Animations

### DIFF
--- a/src/Diagrams/Backend/SVG.hs
+++ b/src/Diagrams/Backend/SVG.hs
@@ -349,7 +349,7 @@ attributedRender svg = do
   let (transOriginAttr, transElement) = case getAttr sty of
         Nothing -> ([], mempty)
         Just (TransformAnimationAttribute animations t) ->
-          ( pure . makeAttribute "transform-origin" . (\(P (V2 x y)) -> showNum x <> " " <> showNum y) $ transform t 1
+          ( pure . makeAttribute "transform-origin" . (\(P (V2 x y)) -> showNum x <> " " <> showNum y) $ transform t 0
           , flip foldMap animations $ \(TransformAnimation dur rep animation) -> animateTransform_ $
               [ AttributeName_ <<- "transform"
               , Additive_ <<- "sum"

--- a/src/Diagrams/Backend/SVG.hs
+++ b/src/Diagrams/Backend/SVG.hs
@@ -362,7 +362,7 @@ attributedRender svg = do
                   ]
                 TranslateAnimation values ->
                   [ Type_ <<- "translate"
-                  , Values_ <<- T.intercalate ";" (map (\(V2 x y) -> showNum x <> "," <> showNum y) values)
+                  , Values_ <<- T.intercalate ";" (map ((\(V2 x y) -> showNum x <> "," <> showNum y) . apply t) values)
                   ]
             )
   return $ do

--- a/src/Diagrams/Backend/SVG.hs
+++ b/src/Diagrams/Backend/SVG.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE TypeSynonymInstances       #-}
 
@@ -108,6 +109,11 @@ module Diagrams.Backend.SVG
   , renderPretty
   , renderPretty'
   , loadImageSVG
+
+  , animate
+  , TransformAnimation (..)
+  , TransformAnimationType (..)
+  , TransformAnimationAttribute (..)
   ) where
 
 -- from JuicyPixels
@@ -127,6 +133,7 @@ import           System.FilePath
 import           Control.Monad.Reader
 import           Control.Monad.State
 import           Data.Char
+import           Data.Fixed
 import           Data.Function            (on)
 import           Data.Typeable
 
@@ -339,9 +346,54 @@ attributedRender svg = do
   clippedSvg   <- renderSvgWithClipping preT svg sty
   lineGradDefs <- lineTextureDefs sty
   fillGradDefs <- fillTextureDefs sty
+  let (transOriginAttr, transElement) = case getAttr sty of
+        Nothing -> ([], mempty)
+        Just (TransformAnimationAttribute animations t) ->
+          ( pure . makeAttribute "transform-origin" . (\(P (V2 x y)) -> showNum x <> " " <> showNum y) $ transform t 1
+          , flip foldMap animations $ \(TransformAnimation dur rep animation) -> animateTransform_ $
+              [ AttributeName_ <<- "transform"
+              , Additive_ <<- "sum"
+              , Dur_ <<- T.show dur <> "s"
+              , RepeatCount_ <<- maybe "indefinite" T.show rep
+              ] <> case animation of
+                ScaleAnimation values ->
+                  [ Type_ <<- "scale"
+                  , Values_ <<- T.intercalate ";" (map (\(V2 x y) -> showNum x <> "," <> showNum y) values)
+                  ]
+                TranslateAnimation values ->
+                  [ Type_ <<- "translate"
+                  , Values_ <<- T.intercalate ";" (map (\(V2 x y) -> showNum x <> "," <> showNum y) values)
+                  ]
+            )
   return $ do
     let gDefs = mappend fillGradDefs lineGradDefs
-    gDefs `mappend` g_ (R.renderStyles idFill idLine sty) clippedSvg
+    gDefs `mappend` g_ (transOriginAttr <> R.renderStyles idFill idLine sty) (transElement <> clippedSvg)
+  where
+    showNum = T.pack . showFixed @E3 True . realToFrac
+
+data TransformAnimationAttribute = TransformAnimationAttribute
+  [TransformAnimation]
+  (Transformation V2 Double)
+data TransformAnimation = TransformAnimation
+  Int -- ^ duration (seconds)
+  (Maybe Double) -- ^ repeat count - `Nothing` to repeat indefinitely
+  TransformAnimationType
+data TransformAnimationType
+  = ScaleAnimation [V2 Double]
+  | TranslateAnimation [V2 Double]
+
+instance AttributeClass TransformAnimationAttribute
+type instance V TransformAnimationAttribute = V2
+type instance N TransformAnimationAttribute = Double
+instance Semigroup TransformAnimationAttribute where
+  TransformAnimationAttribute xs tx <> TransformAnimationAttribute ys ty =
+    TransformAnimationAttribute (xs <> ys) (tx <> ty)
+instance Transformable TransformAnimationAttribute where
+  transform t (TransformAnimationAttribute a t0) =
+    TransformAnimationAttribute a (t <> t0)
+
+animate :: (HasStyle d, V d ~ V2, N d ~ Double) => TransformAnimation -> d -> d
+animate a = applyTAttr $ TransformAnimationAttribute [a] mempty
 
 instance SVGFloat n => Renderable (Path V2 n) SVG where
   render _ = R . attributedRender . R.renderPath

--- a/src/Diagrams/Backend/SVG.hs
+++ b/src/Diagrams/Backend/SVG.hs
@@ -132,6 +132,7 @@ import           System.FilePath
 -- from base
 import           Control.Monad.Reader
 import           Control.Monad.State
+import           Data.Bifunctor
 import           Data.Char
 import           Data.Fixed
 import           Data.Function            (on)
@@ -364,6 +365,10 @@ attributedRender svg = do
                   [ Type_ <<- "translate"
                   , Values_ <<- T.intercalate ";" (map ((\(V2 x y) -> showNum x <> "," <> showNum y) . apply t) values)
                   ]
+                RotateAnimation values ->
+                  [ Type_ <<- "rotate"
+                  , Values_ <<- T.intercalate ";" (map ((\(a, p) -> showNum (a ^. deg) <> maybe mempty (\(P (V2 x y)) -> "," <> showNum x <> "," <> showNum y) p) . second (fmap (papply t))) values)
+                  ]
             )
   return $ do
     let gDefs = mappend fillGradDefs lineGradDefs
@@ -381,6 +386,7 @@ data TransformAnimation = TransformAnimation
 data TransformAnimationType
   = ScaleAnimation [V2 Double]
   | TranslateAnimation [V2 Double]
+  | RotateAnimation [(Angle Double, Maybe (P2 Double))]
 
 instance AttributeClass TransformAnimationAttribute
 type instance V TransformAnimationAttribute = V2


### PR DESCRIPTION
This is obviously a work-in-progress, but I wanted to get feedback as early as possible, in particular on whether something like this is likely to be accepted upstream.

This uses the [`animateTransform`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/animateTransform) element to animate arbitrary subdiagrams. It's part of the standard, though unfortunately not yet widely supported by non-web SVG viewers (I've been using Gnome's Epiphany web browser for testing, as it's the only tool I've found which shows animations _and_ auto-reloads on changes to a local file). We should also support [`animateMotion`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/animateMotion), potentially taking a Diagrams `Path`, as this allows for translations along a smooth curve. There's also [`animate`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/animate), but that seems too ad-hoc to be useful in the context of Diagrams.

I've linked to MDN there, but actually much of this API is poorly-documented everywhere but [the official spec](https://svgwg.org/specs/animations/#AnimateTransformElement). In particular, I've seen no good explanation elsewhere of the `values` attribute, which we use here as it's necessary for any animations which go through multiple states, rather than just smoothly from A to B. We should check this spec to make sure we cover everything important in our API surface.

@byorgey I know you've hinted at developing a completely new approach to animations in Diagrams for a long time. I'd love to know more about what sort of API you're aiming for, as I've been unable to find any details. I have always assumed it's still fundamentally similar to the general-but-inefficient "lists of diagrams" stuff that one sees in e.g. `diagrams-rasterific` for GIF generation. But perhaps you had an abstraction in mind which would support native animations in the SVG backend?

Regardless, this SVG-specific approach has been highly useful, especially with Reanimate seemingly no longer maintained, and it's allowed us to avoid needing #126.

CC @patrickaldis @cgibbard